### PR TITLE
Update some old names to better nomenclature.

### DIFF
--- a/docs/custom_input_handlers.md
+++ b/docs/custom_input_handlers.md
@@ -15,7 +15,7 @@ for use.
 Handler classes
 ---------------
 
-Handlers are implemented by subclasses of `tangos.input_handlers.SimulationOutputSetHandler`.
+Handlers are implemented by subclasses of `tangos.input_handlers.HandlerBase`.
 To write your own, start by creating such a subclass. At a minimum will need to provide a way for _tangos_:
 
  - to enumerate the available simulation timesteps. This is the method 
@@ -51,7 +51,7 @@ class MyDataObject(object):
     def __repr__(self):
         return str(self.internal_data)
 
-class MyHandler(tangos.input_handlers.SimulationOutputSetHandler):
+class MyHandler(tangos.input_handlers.HandlerBase):
     def enumerate_timestep_extensions(self):
         return ["my_timestep_1", "my_timestep_2"]
 

--- a/docs/custom_input_handlers.md
+++ b/docs/custom_input_handlers.md
@@ -174,7 +174,7 @@ be in the same file, of course) as follows:
 ```python
 from tangos import properties
 
-class MyProperty(properties.HaloProperties):
+class MyProperty(properties.PropertyCalculation):
     works_with_handler = MyHandler
 
     names = "my_fantastic_property"

--- a/docs/custom_properties.md
+++ b/docs/custom_properties.md
@@ -21,9 +21,9 @@ Therefore the simplest possible example consists of a single class which defines
 Create a new python file and name it `mytangosproperty.py` with the following contents:
 
 ```python
-from tangos.properties import HaloProperties
+from tangos.properties import PropertyCalculation
 
-class ExampleHaloProperty(HaloProperties):
+class ExampleHaloProperty(PropertyCalculation):
     names = "myproperty"
     
     def calculate(self, particle_data, existing_properties):
@@ -31,7 +31,7 @@ class ExampleHaloProperty(HaloProperties):
 ```
 
 This corresponds to a property in the database with the name `myproperty` which is always `42.0` for every halo.
-Note that the classes you create _must_ be derived from `tangos.properties.HaloProperties` as above, 
+Note that the classes you create _must_ be derived from `tangos.properties.PropertyCalculation` as above, 
 otherwise _tangos_ will not understand your intention. 
 
 Now we need to make your class visible to _tangos_.
@@ -75,9 +75,9 @@ the center of each halo, this can be inferred from existing properties without t
 Modify `mytangosproperty.py` to read:
 
 ```python
-from tangos.properties import HaloProperties
+from tangos.properties import PropertyCalculation
 
-class ExampleHaloProperty(HaloProperties):
+class ExampleHaloProperty(PropertyCalculation):
     names = 'my_x'
     
     def calculate(self, particle_data, existing_properties):
@@ -129,9 +129,9 @@ It's often desirable to calculate multiple closely-related properties in one cla
 just add the names and return a list or tuple of values:
 
 ```python
-from tangos.properties import HaloProperties
+from tangos.properties import PropertyCalculation
 
-class ExampleHaloProperty(HaloProperties):
+class ExampleHaloProperty(PropertyCalculation):
     names = "my_x", "my_y", "my_z"
 
     def calculate(self, particle_data, existing_properties):
@@ -150,17 +150,17 @@ Let's now implement a property that requires access to the underlying particle d
 the velocity dispersion of the halo:
 
 ```python
-from tangos.properties.pynbody import PynbodyHaloProperties
+from tangos.properties.pynbody import PynbodyPropertyCalculation
 import numpy as np
 
-class ExampleHaloProperty(PynbodyHaloProperties):
+class ExampleHaloProperty(PynbodyPropertyCalculation):
     names = "velocity_dispersion"
     
     def calculate(self, particle_data, existing_properties):
         return np.std(particle_data['vel'])
 ```
 
-By deriving from `PynbodyHaloProperties` instead of `HaloProperties`, you are indicating to _tangos_ 
+By deriving from `PynbodyPropertyCalculation` instead of `PropertyCalculation`, you are indicating to _tangos_ 
 that this property can only be calculated with reference
 to the _pynbody_-loaded original particle data associated with the halo. (Note that there is an [equivalent
 for yt](using_with_yt.md), and you can make your [own customised loaders](custom_input_handlers.md) 
@@ -207,10 +207,10 @@ halo finder defined. In the following example, we go out to a sphere of twice th
 
 
 ```python
-from tangos.properties.pynbody import PynbodyHaloProperties
+from tangos.properties.pynbody import PynbodyPropertyCalculation
 import pynbody
 
-class ExampleHaloProperty(PynbodyHaloProperties):
+class ExampleHaloProperty(PynbodyPropertyCalculation):
     names = "my_virial_radius"
     
     def calculate(self, particle_data, existing_properties):
@@ -251,11 +251,11 @@ out requires access to the position of all halos within a timestep. This is poss
 consider the following implementation:
 
 ```python
-from tangos.properties import HaloProperties
+from tangos.properties import PropertyCalculation
 from tangos import get_halo
 import numpy as np
 
-class ExampleHaloProperty(HaloProperties):
+class ExampleHaloProperty(PropertyCalculation):
     names = "my_parent_halo"
     
     def calculate(self, particle_data, existing_properties):

--- a/docs/using_with_yt.md
+++ b/docs/using_with_yt.md
@@ -29,7 +29,7 @@ Using yt to add a simulation
 At the unix command line type:
 
 ```
-tangos add tutorial_changa_yt --handler=yt.YtOutputSetHandler
+tangos add tutorial_changa_yt --handler=yt.YtInputHandler
 ```
 
 The process should take about a minute on a standard modern computer, during which you'll see a bunch of log messages 
@@ -40,7 +40,7 @@ scroll up the screen.
   * `tangos` is the command-line tool to administrate your tangos database
   * `add` is a subcommand to add a new simulation
   * `tutorial_changa_yt` identifies the simulation we're adding
-  * `--handler=yt.YtOutputSetHandler` requests that _tangos_ uses yt as the "handler" for raw simulation and halo files.
+  * `--handler=yt.YtInputHandler` requests that _tangos_ uses yt as the "handler" for raw simulation and halo files.
   
 
 Verify the underlying data is being read by yt

--- a/tangos/config.py
+++ b/tangos/config.py
@@ -11,7 +11,7 @@ home = os.environ['HOME']
 db = os.environ.get("TANGOS_DB_CONNECTION", home+"/tangos_data.db")
 base = os.environ.get("TANGOS_SIMULATION_FOLDER", home+"/")
 
-default_fileset_handler_class = "pynbody.PynbodyOutputSetHandler"
+default_fileset_handler_class = "pynbody.PynbodyInputHandler"
 
 num_multihops_max_default = 100
 # the maximum number of links to follow when searching for related halos

--- a/tangos/core/halo.py
+++ b/tangos/core/halo.py
@@ -114,19 +114,30 @@ class Halo(Base):
         return self._handler_class
 
     def load(self, mode=None):
-        """Use pynbody to load the data for this halo, if it is present on this computer's filesystem.
+        """Load the data for this halo, if it is present on this computer's filesystem.
 
-        By default, the entire simulation is loaded and a subview with this halo is returned. If mode='partial',
-        pynbody's partial loading system is used to only load the data for the one halo, saving memory."""
+        :param mode: the load mode to pass to the relevant input handler. For example with the pynbody input
+        handler this can be None or 'partial' (in a normal session) and, when running inside an MPI session,
+        'server' or 'server-partial'. See https://pynbody.github.io/tangos/mpi.html.
+        """
 
         return self.handler.load_object(self.timestep.extension, self.finder_id, object_typetag=self.tag, mode=mode)
 
-    def calculate(self, name, return_description=False):
+    def calculate(self, calculation, return_description=False):
         """Use the live-calculation system to calculate a user-specified function of the stored data.
 
-        See live_calculation.md for an introduction to this powerful functionality."""
+        See the data exploration tutorials at https://pynbody.github.io/tangos/data_exploration.html
+        for an introduction to the system.
+
+        :param calculation: the calculation (or a string representation of it to be parsed)
+        :param return_description: if True, return both the value and the PropertyCalculation class describing it.
+        :returns: The result of the calculation, or a tuple containing the result and the description if
+                  return_description is True.
+
+        """
+
         from .. import live_calculation
-        calculation = live_calculation.parser.parse_property_name_if_required(name)
+        calculation = live_calculation.parser.parse_property_name_if_required(calculation)
         (value,), description = calculation.values_sanitized_and_description([self], Session.object_session(self))
         if len(value)==1:
             retval = value[0]

--- a/tangos/core/simulation.py
+++ b/tangos/core/simulation.py
@@ -37,9 +37,9 @@ class Simulation(Base):
             return default
 
     def get_output_handler(self):
-        """Get a SimulationOutputSetHandler object, pre-configured suitably for this simulation
+        """Get a HandlerBase object, pre-configured suitably for this simulation
 
-        :rtype simulation_outputs.SimulationOutputSetHandler"""
+        :rtype simulation_outputs.HandlerBase"""
         if not hasattr(self, "_handler"):
             handler_class = self.output_handler_class
             self._handler = handler_class(self.basename)

--- a/tangos/input_handlers/__init__.py
+++ b/tangos/input_handlers/__init__.py
@@ -28,7 +28,7 @@ class DummyTimeStep(object):
 _loaded_timesteps = {}
 
 
-class SimulationOutputSetHandler(object):
+class HandlerBase(object):
     """This class handles the output from a simulation as it resides on disk.
 
     Subclasses provide implementations for different formats and situations.
@@ -140,8 +140,8 @@ class SimulationOutputSetHandler(object):
     @classmethod
     def handler_class_name(cls):
         module = cls.__module__
-        if module.startswith(SimulationOutputSetHandler.__module__):
-            submodule = module[len(SimulationOutputSetHandler.__module__)+1:]
+        if module.startswith(HandlerBase.__module__):
+            submodule = module[len(HandlerBase.__module__)+1:]
             return submodule+"."+cls.__name__
         else:
             return module+"."+cls.__name__
@@ -165,11 +165,11 @@ class SimulationOutputSetHandler(object):
 
 
 def get_named_handler_class(handler):
-    """Get a SimulationOutputSetHandler identified by the given name.
+    """Get a HandlerBase identified by the given name.
 
     The name is of the format submodule.ClassName
 
-    :rtype SimulationOutputSetHandler"""
+    :rtype HandlerBase"""
     try:
         output_module = importlib.import_module('.'+handler.split('.')[0],__name__)
     except ImportError:

--- a/tangos/input_handlers/output_testing.py
+++ b/tangos/input_handlers/output_testing.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import glob
 import os, os.path
 from .. import config
-from . import SimulationOutputSetHandler
+from . import HandlerBase
 from six.moves import range
 
 class DummyTimestepData(object):
@@ -16,7 +16,7 @@ class DummyTimestepData(object):
     def __str__(self):
         return self.message
 
-class TestOutputSetHandler(SimulationOutputSetHandler):
+class TestInputHandler(HandlerBase):
     def get_properties(self):
         result = {}
         with open(os.path.join(config.base, self.basename, "sim_info"),'r') as f:
@@ -87,7 +87,7 @@ class TestOutputSetHandler(SimulationOutputSetHandler):
                     return " ".join(line_split[1:])
 
 
-class TestOutputSetHandlerReverseHaloNDM(TestOutputSetHandler):
+class TestInputHandlerReverseHaloNDM(TestInputHandler):
     def enumerate_objects(self, ts_extension, object_typetag='halo', min_halo_particles=config.min_halo_particles):
         nhalos_string = self._get_ts_property(ts_extension, object_typetag+"s")
         nhalos = 0 if nhalos_string is None else int(nhalos_string)

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -8,10 +8,10 @@ import weakref
 import re
 import numpy as np
 
-pynbody = None # deferred import; occurs when a PynbodyOutputSetHandler is constructed
+pynbody = None # deferred import; occurs when a PynbodyInputHandler is constructed
 
 from . import halo_stat_files, finding
-from . import SimulationOutputSetHandler
+from . import HandlerBase
 from .. import config
 from ..log import logger
 from six.moves import range
@@ -30,9 +30,9 @@ class DummyTimeStep(object):
     pass
 
 
-class PynbodyOutputSetHandler(finding.PatternBasedFileDiscovery, SimulationOutputSetHandler):
+class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
     def __init__(self, *args, **kwargs):
-        super(PynbodyOutputSetHandler, self).__init__(*args, **kwargs)
+        super(PynbodyInputHandler, self).__init__(*args, **kwargs)
 
         import pynbody as pynbody_local
 
@@ -189,7 +189,7 @@ class PynbodyOutputSetHandler(finding.PatternBasedFileDiscovery, SimulationOutpu
         h1 = self._construct_halo_cat(ts1, object_typetag)
 
         if output_handler_for_ts2:
-            assert isinstance(output_handler_for_ts2, PynbodyOutputSetHandler)
+            assert isinstance(output_handler_for_ts2, PynbodyInputHandler)
             f2 = output_handler_for_ts2.load_timestep(ts2)
             h2 = output_handler_for_ts2._construct_halo_cat(ts2, object_typetag)
         else:
@@ -272,7 +272,7 @@ class PynbodyOutputSetHandler(finding.PatternBasedFileDiscovery, SimulationOutpu
         return res
 
 
-class RamsesHOPOutputSetHandler(PynbodyOutputSetHandler):
+class RamsesHOPInputHandler(PynbodyInputHandler):
     patterns = ["output_0????"]
 
     def match_objects(self, ts1, ts2, halo_min, halo_max,
@@ -292,7 +292,7 @@ class RamsesHOPOutputSetHandler(PynbodyOutputSetHandler):
 
 
 
-class GadgetSubfindOutputSetHandler(PynbodyOutputSetHandler):
+class GadgetSubfindInputHandler(PynbodyInputHandler):
     patterns = ["snapshot_???"]
 
     def load_object(self, ts_extension, halo_number, object_typetag='halo', mode=None):
@@ -300,7 +300,7 @@ class GadgetSubfindOutputSetHandler(PynbodyOutputSetHandler):
             h = self._construct_halo_cat(ts_extension, object_typetag)
             return h.get_halo_properties(halo_number,with_unit=False)
         else:
-            return super(GadgetSubfindOutputSetHandler, self).load_object(ts_extension, halo_number, object_typetag, mode)
+            return super(GadgetSubfindInputHandler, self).load_object(ts_extension, halo_number, object_typetag, mode)
 
 
 
@@ -324,7 +324,7 @@ class GadgetSubfindOutputSetHandler(PynbodyOutputSetHandler):
 
     def _construct_halo_cat(self, ts_extension, object_typetag):
         if object_typetag== 'halo':
-            return super(GadgetSubfindOutputSetHandler, self)._construct_halo_cat(ts_extension, object_typetag)
+            return super(GadgetSubfindInputHandler, self)._construct_halo_cat(ts_extension, object_typetag)
         elif object_typetag== 'group':
             return self._construct_group_cat(ts_extension)
         else:
@@ -333,7 +333,7 @@ class GadgetSubfindOutputSetHandler(PynbodyOutputSetHandler):
 
 
 
-class ChangaOutputSetHandler(PynbodyOutputSetHandler):
+class ChangaInputHandler(PynbodyInputHandler):
     flags_include = ["dPhysDenMin", "dCStar", "dTempMax",
                      "dESN", "bLowTCool", "bSelfShield", "dExtraCoolShutoff"]
 
@@ -341,7 +341,7 @@ class ChangaOutputSetHandler(PynbodyOutputSetHandler):
 
 
     def get_properties(self):
-        parent_prop_dict = super(ChangaOutputSetHandler, self).get_properties()
+        parent_prop_dict = super(ChangaInputHandler, self).get_properties()
 
         pfile = self._get_paramfile_path()
 

--- a/tangos/input_handlers/yt.py
+++ b/tangos/input_handlers/yt.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import
 
-yt = None # deferred import; occurs when a YtOutputSetHandler is constructed
+yt = None # deferred import; occurs when a YtInputHandler is constructed
 
 from . import finding
-from . import SimulationOutputSetHandler
+from . import HandlerBase
 from .. import config
 from ..log import logger
 from six.moves import range
 
-class YtOutputSetHandler(finding.PatternBasedFileDiscovery, SimulationOutputSetHandler):
+class YtInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
     def __init__(self, *args, **kwargs):
-        super(YtOutputSetHandler, self).__init__(*args, **kwargs)
+        super(YtInputHandler, self).__init__(*args, **kwargs)
         global yt
         import yt as yt_local
         yt = yt_local
@@ -78,13 +78,13 @@ class YtOutputSetHandler(finding.PatternBasedFileDiscovery, SimulationOutputSetH
             raise ValueError("Unknown halo type %r" % object_typetag)
 
     def _load_halo_cat_without_caching(self, ts_extension, snapshot_file):
-        raise NotImplementedError("You need to select a subclass of YtOutputSetHandler")
+        raise NotImplementedError("You need to select a subclass of YtInputHandler")
 
     def get_properties(self):
         return {}
 
 
-class YtChangaAHFOutputSetHandler(YtOutputSetHandler):
+class YtChangaAHFInputHandler(YtInputHandler):
     patterns = ["*.00???", "*.00????"]
 
     def _load_halo_cat_without_caching(self, ts_extension, snapshot_file):

--- a/tangos/live_calculation/__init__.py
+++ b/tangos/live_calculation/__init__.py
@@ -120,12 +120,12 @@ class Calculation(object):
                 session.close()
 
     def values_and_description(self, halos):
-        """Return the values of this calculation, as well as a HaloProperties object describing the
+        """Return the values of this calculation, as well as a PropertyCalculation object describing the
         properties of these values (if possible)"""
         raise NotImplementedError
 
     def values_sanitized_and_description(self, halos, load_into_session=None):
-        """Return the 'sanitized' values of this calculation, as well as a HaloProperties object (if available).
+        """Return the 'sanitized' values of this calculation, as well as a PropertyCalculation object (if available).
 
         See values_sanitized for the definition of sanitized"""
         values, desc = self.values_and_description(halos)

--- a/tangos/properties/__init__.py
+++ b/tangos/properties/__init__.py
@@ -29,8 +29,8 @@ class PropertyCalculation(six.with_metaclass(PropertyCalculationMetaClass,object
 
     # In child class, defines the most general handler that this property is compatible with.
     # If unchanged, it is compatible with all handlers. Typically it will be appropriate to specify something more
-    # restrictive e.g. input_handlers.pynbody.PynbodyOutputSetHandler
-    works_with_handler = input_handlers.SimulationOutputSetHandler
+    # restrictive e.g. input_handlers.pynbody.PynbodyInputHandler
+    works_with_handler = input_handlers.HandlerBase
 
     # Specifies whether the particle data needs to be provided for this class to perform a calculation; if
     # False, only existing PropertyCalculation are required by this calculation (see requires_property below).

--- a/tangos/properties/__init__.py
+++ b/tangos/properties/__init__.py
@@ -9,8 +9,8 @@ import functools
 from .. import input_handlers
 
 
-class HaloPropertiesMetaClass(type):
-    # Present to register new subclasses of HaloProperties, so that subclasses can be dynamically
+class PropertyCalculationMetaClass(type):
+    # Present to register new subclasses of PropertyCalculation, so that subclasses can be dynamically
     # instantiated when required based on their cls.names values. Stored as a dictionary so that
     # reloaded classes overwrite their old versions.
     def __init__(cls, name, bases, dict):
@@ -24,7 +24,7 @@ class HaloPropertiesMetaClass(type):
         if cls.names is not None:
             cls._all_classes.append(cls)
 
-class HaloProperties(six.with_metaclass(HaloPropertiesMetaClass,object)):
+class PropertyCalculation(six.with_metaclass(PropertyCalculationMetaClass,object)):
     _all_classes = []
 
     # In child class, defines the most general handler that this property is compatible with.
@@ -33,7 +33,7 @@ class HaloProperties(six.with_metaclass(HaloPropertiesMetaClass,object)):
     works_with_handler = input_handlers.SimulationOutputSetHandler
 
     # Specifies whether the particle data needs to be provided for this class to perform a calculation; if
-    # False, only existing HaloProperties are required by this calculation (see requires_property below).
+    # False, only existing PropertyCalculation are required by this calculation (see requires_property below).
     requires_particle_data = False
 
     # Specifies a tuple of names of properties that will be calculated by this class.
@@ -44,7 +44,7 @@ class HaloProperties(six.with_metaclass(HaloPropertiesMetaClass,object)):
         return cls._all_classes
 
     def __init__(self, simulation):
-        """Initialise a HaloProperties calculation object
+        """Initialise a PropertyCalculation calculation object
 
         :param simulation: The simulation from which the properties will be derived
         :type simulation: tangos.core.simulation.Simulation
@@ -57,7 +57,7 @@ class HaloProperties(six.with_metaclass(HaloPropertiesMetaClass,object)):
         """Returns the index of the named property in the
         results returned from calculate().
 
-        For example, for a BasicHaloProperties object X,
+        For example, for a BasicPropertyCalculation object X,
         X.calculate(..)[X.index_of_name("SSC")] returns the SSC.
         """
         name = name.split("(")[0]
@@ -86,7 +86,7 @@ class HaloProperties(six.with_metaclass(HaloPropertiesMetaClass,object)):
         """Returns an abstract specification of the region that this halo property is to be calculated on,
         or None if we want the halo particles as defined by the finder.
 
-        See spherical_region.SphericalRegionHaloProperties for an example and useful base class for returning
+        See spherical_region.SphericalRegionPropertyCalculation for an example and useful base class for returning
         everything within the virial radius."""
         return None
 
@@ -197,7 +197,9 @@ class HaloProperties(six.with_metaclass(HaloPropertiesMetaClass,object)):
     def plot_clabel(self):
         return None
 
-class TimeChunkedProperty(HaloProperties):
+HaloProperties = PropertyCalculation # old name, to be deprecated
+
+class TimeChunkedProperty(PropertyCalculation):
     """TimeChunkedProperty implements a special type of halo property where chunks of a histogram are stored
     at each time step, then appropriately reassembled when the histogram is retrieved."""
 
@@ -298,27 +300,28 @@ class TimeChunkedProperty(HaloProperties):
 
 
 
-class LiveHaloProperties(HaloProperties):
+class LivePropertyCalculation(PropertyCalculation):
     requires_particle_data = False
 
     def __init__(self, simulation, *args):
-        super(LiveHaloProperties, self).__init__(simulation)
+        super(LivePropertyCalculation, self).__init__(simulation)
         self._nargs = len(args)
 
     def calculate(self, _, halo):
         return self.live_calculate(halo, *([None]*self._nargs))
 
+LiveHaloProperties = LivePropertyCalculation # old name, to be deprecated
 
-class LiveHaloPropertiesInheritingMetaProperties(LiveHaloProperties):
-    """LiveHaloProperties which inherit the meta-data (i.e. x0, delta_x values etc) from
+class LivePropertyCalculationInheritingMetaProperties(LivePropertyCalculation):
+    """LivePropertyCalculation which inherit the meta-data (i.e. x0, delta_x values etc) from
     one of the input arguments"""
     def __init__(self, simulation, inherits_from, *args):
         """
         :param simulation: The simulation DB entry for this instance
-        :param inherits_from: The HaloProperties description from which the metadata should be inherited
-        :type inherits_from: HaloProperties
+        :param inherits_from: The PropertyCalculation description from which the metadata should be inherited
+        :type inherits_from: PropertyCalculation
         """
-        super(LiveHaloPropertiesInheritingMetaProperties, self).__init__(simulation)
+        super(LivePropertyCalculationInheritingMetaProperties, self).__init__(simulation)
         self._inherits_from = inherits_from(simulation)
 
     def plot_x0(self):
@@ -344,9 +347,9 @@ class ProxyHalo(object):
 ##############################################################################
 
 def all_property_classes():
-    """Return list of all classes derived from HaloProperties"""
+    """Return list of all classes derived from PropertyCalculation"""
 
-    return HaloProperties.all_classes()
+    return PropertyCalculation.all_classes()
 
 
 
@@ -355,7 +358,7 @@ def _check_class_provided_name(name):
         raise ValueError("Property names must not include brackets; %s not suitable"%name)
 
 def all_properties(with_particle_data=True):
-    """Return list of all properties which can be calculated using classes derived from HaloProperties"""
+    """Return list of all properties which can be calculated using classes derived from PropertyCalculation"""
     classes = all_property_classes()
     pr = []
     for c in classes:

--- a/tangos/properties/intrinsic.py
+++ b/tangos/properties/intrinsic.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
-from . import LiveHaloProperties
+from . import LivePropertyCalculation
 
-class IntrinsicProperties(LiveHaloProperties):
+class IntrinsicProperties(LivePropertyCalculation):
     names = "t","z","a","dbid", "halo_number", "NDM", "NStar", "NGas", "type", "step_path"
 
     def live_calculate(self, halo):

--- a/tangos/properties/live_profiles.py
+++ b/tangos/properties/live_profiles.py
@@ -1,9 +1,9 @@
 # Live properties suitable for calculations on underlying profiles, e.g. density profiles, mass profiles etc
 
-from . import LiveHaloProperties
+from . import LivePropertyCalculation
 import numpy as np
 
-class AtPosition(LiveHaloProperties):
+class AtPosition(LivePropertyCalculation):
     def __init__(self, simulation, position, array):
         super(AtPosition, self).__init__(simulation)
         self._array_info = array
@@ -27,7 +27,7 @@ class AtPosition(LiveHaloProperties):
         else:
             return ar[i0]*i0_weight + ar[i1]*i1_weight
 
-class MaxMinProperty(LiveHaloProperties):
+class MaxMinProperty(LivePropertyCalculation):
     def __init__(self, simulation, array):
         super(MaxMinProperty, self).__init__(simulation)
         self._array_info = array

--- a/tangos/properties/pynbody/BH.py
+++ b/tangos/properties/pynbody/BH.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 import tangos.core.halo
 from tangos.input_handlers.changa_bh import BHShortenedLog
-from . import PynbodyHaloProperties
-from .. import LiveHaloProperties, TimeChunkedProperty
+from . import PynbodyPropertyCalculation
+from .. import LivePropertyCalculation, TimeChunkedProperty
 import numpy as np
 import scipy, scipy.interpolate
 
 
-class BH(PynbodyHaloProperties):
+class BH(PynbodyPropertyCalculation):
 
     names = "BH_mdot", "BH_mdot_ave", "BH_mdot_std", "BH_central_offset", "BH_central_distance", "BH_mass"
     requires_particle_data = True
@@ -123,7 +123,7 @@ class BHAccHistogram(TimeChunkedProperty):
         return Mdot_grid[self.store_slice(t_max)]
 
 
-class BHAccHistogramMerged(PynbodyHaloProperties):
+class BHAccHistogramMerged(PynbodyPropertyCalculation):
     names = "BH_mdot_histogram_all"
 
     @classmethod
@@ -154,7 +154,7 @@ class BHAccHistogramMerged(PynbodyHaloProperties):
         return mdot
 
 
-class BHGal(LiveHaloProperties):
+class BHGal(LivePropertyCalculation):
     def __init__(self, simulation=None, choose='BH_mass', minmax='max', bhtype='BH_central'):
         super(BHGal, self).__init__(simulation)
         self._maxmin = minmax

--- a/tangos/properties/pynbody/SF.py
+++ b/tangos/properties/pynbody/SF.py
@@ -4,7 +4,7 @@ from . import pynbody_handler_module
 import numpy as np
 
 class StarFormHistogram(TimeChunkedProperty):
-    works_with_handler = pynbody_handler_module.PynbodyOutputSetHandler
+    works_with_handler = pynbody_handler_module.PynbodyInputHandler
     requires_particle_data = True
 
     @classmethod

--- a/tangos/properties/pynbody/__init__.py
+++ b/tangos/properties/pynbody/__init__.py
@@ -2,7 +2,7 @@ from .. import PropertyCalculation
 from ...input_handlers import pynbody as pynbody_handler_module
 
 class PynbodyPropertyCalculation(PropertyCalculation):
-    works_with_handler = pynbody_handler_module.PynbodyOutputSetHandler
+    works_with_handler = pynbody_handler_module.PynbodyInputHandler
     requires_particle_data = True
 
 PynbodyHaloProperties = PynbodyPropertyCalculation # old name, to be deprecated

--- a/tangos/properties/pynbody/__init__.py
+++ b/tangos/properties/pynbody/__init__.py
@@ -1,8 +1,10 @@
-from .. import HaloProperties
+from .. import PropertyCalculation
 from ...input_handlers import pynbody as pynbody_handler_module
 
-class PynbodyHaloProperties(HaloProperties):
+class PynbodyPropertyCalculation(PropertyCalculation):
     works_with_handler = pynbody_handler_module.PynbodyOutputSetHandler
     requires_particle_data = True
+
+PynbodyHaloProperties = PynbodyPropertyCalculation # old name, to be deprecated
 
 from . import BH, SF, zoom, centring, profile, images, gas

--- a/tangos/properties/pynbody/centring.py
+++ b/tangos/properties/pynbody/centring.py
@@ -1,10 +1,10 @@
-from . import PynbodyHaloProperties
-from .. import LiveHaloProperties
+from . import PynbodyPropertyCalculation
+from .. import LivePropertyCalculation
 import numpy as np
 import functools
 import contextlib
 
-class CentreAndRadius(PynbodyHaloProperties):
+class CentreAndRadius(PynbodyPropertyCalculation):
     names = "shrink_center", "max_radius"
 
     def calculate(self, halo, existing_properties):
@@ -35,7 +35,7 @@ class CentreAndRadius(PynbodyHaloProperties):
         return center.view(np.ndarray), rmax
 
 
-class CentreAndRadiusComoving(LiveHaloProperties):
+class CentreAndRadiusComoving(LivePropertyCalculation):
     names = "shrink_center_comoving", "max_radius_comoving"
 
     def calculate(self, _, existing_properties):

--- a/tangos/properties/pynbody/gas.py
+++ b/tangos/properties/pynbody/gas.py
@@ -1,6 +1,6 @@
-from . import PynbodyHaloProperties
+from . import PynbodyPropertyCalculation
 
-class MeanGasProperties(PynbodyHaloProperties):
+class MeanGasProperties(PynbodyPropertyCalculation):
     @classmethod
     def name(self):
         return "mean_temp", "mean_rho"

--- a/tangos/properties/pynbody/images.py
+++ b/tangos/properties/pynbody/images.py
@@ -1,7 +1,7 @@
-from .spherical_region import SphericalRegionHaloProperties
+from .spherical_region import SphericalRegionPropertyCalculation
 from .centring import centred_calculation
 
-class BaryonicImages(SphericalRegionHaloProperties):
+class BaryonicImages(SphericalRegionPropertyCalculation):
     names = "gas_map_sideon", "uvi_image_sideon", "gas_map_faceon", "uvi_image_faceon", "gas_map", "uvi_image"
 
     @classmethod

--- a/tangos/properties/pynbody/profile.py
+++ b/tangos/properties/pynbody/profile.py
@@ -1,8 +1,8 @@
 import numpy as np
-from .spherical_region import SphericalRegionHaloProperties
+from .spherical_region import SphericalRegionPropertyCalculation
 from .centring import centred_calculation
 
-class HaloDensityProfile(SphericalRegionHaloProperties):
+class HaloDensityProfile(SphericalRegionPropertyCalculation):
     # include
 
     names = "dm_density_profile", "dm_mass_profile"

--- a/tangos/properties/pynbody/spherical_region.py
+++ b/tangos/properties/pynbody/spherical_region.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
-from . import PynbodyHaloProperties
+from . import PynbodyPropertyCalculation
 
-class SphericalRegionHaloProperties(PynbodyHaloProperties):
+class SphericalRegionPropertyCalculation(PynbodyPropertyCalculation):
     """A base class for calculations which require all data within a sphere (rather than just the literal
     halo finder output)"""
 
@@ -10,5 +10,6 @@ class SphericalRegionHaloProperties(PynbodyHaloProperties):
         return pynbody.filt.Sphere(db_data['max_radius'], db_data['shrink_center'])
 
     def requires_property(self):
-        return ["shrink_center", "max_radius"]+super(SphericalRegionHaloProperties, self).requires_property()
+        return ["shrink_center", "max_radius"]+super(SphericalRegionPropertyCalculation, self).requires_property()
 
+SphericalRegionHaloProperties = SphericalRegionPropertyCalculation # old name, to be deprecated

--- a/tangos/properties/pynbody/zoom.py
+++ b/tangos/properties/pynbody/zoom.py
@@ -1,6 +1,6 @@
-from . import PynbodyHaloProperties
+from . import PynbodyPropertyCalculation
 
-class Contamination(PynbodyHaloProperties):
+class Contamination(PynbodyPropertyCalculation):
 
     def calculate(self, halo, exist):
         n_heavy = (halo.dm['mass'] > self.min_dm_mass).sum()

--- a/tangos/properties/yt/__init__.py
+++ b/tangos/properties/yt/__init__.py
@@ -3,7 +3,7 @@ from ...input_handlers import yt as yt_handler_module
 import numpy as np
 
 class YtPropertyCalculation(PropertyCalculation):
-    works_with_handler = yt_handler_module.YtOutputSetHandler
+    works_with_handler = yt_handler_module.YtInputHandler
     requires_particle_data = True
 
 class HaloDensityProfile(YtPropertyCalculation):

--- a/tangos/properties/yt/__init__.py
+++ b/tangos/properties/yt/__init__.py
@@ -1,12 +1,12 @@
-from .. import HaloProperties
+from .. import PropertyCalculation
 from ...input_handlers import yt as yt_handler_module
 import numpy as np
 
-class YtHaloProperties(HaloProperties):
+class YtPropertyCalculation(PropertyCalculation):
     works_with_handler = yt_handler_module.YtOutputSetHandler
     requires_particle_data = True
 
-class HaloDensityProfile(YtHaloProperties):
+class HaloDensityProfile(YtPropertyCalculation):
     """Proof of concept: get halo density profiles from yt"""
     names = "dm_density_profile", "dm_mass_profile"
 

--- a/tangos/scripts/import_from_subfind.py
+++ b/tangos/scripts/import_from_subfind.py
@@ -79,8 +79,8 @@ def main():
     with db.get_default_session().no_autoflush: # for performance
         for x in base_sim:
             if not isinstance(x.get_output_handler(),
-                              tangos.input_handlers.pynbody.GadgetSubfindOutputSetHandler):
-                raise ValueError("import_from_subfind requires the handler to be SubfindOutputSetHandler")
+                              tangos.input_handlers.pynbody.GadgetSubfindInputHandler):
+                raise ValueError("import_from_subfind requires the handler to be SubfindInputHandler")
             timesteps = db.core.get_default_session().query(tangos.core.timestep.TimeStep).filter_by(
                 simulation_id=x.id, available=True).order_by(tangos.core.timestep.TimeStep.redshift.desc()).all()
 

--- a/tangos/tools/add_simulation.py
+++ b/tangos/tools/add_simulation.py
@@ -9,7 +9,7 @@ class SimulationAdderUpdater(object):
     """This class contains the necessary tools to add a new simulation to the database"""
 
     def __init__(self, simulation_output, session=None, renumber=True):
-        """:type simulation_output tangos.simulation_outputs.SimulationOutputSetHandler"""
+        """:type simulation_output tangos.simulation_outputs.HandlerBase"""
         self.simulation_output = simulation_output
         if session is None:
             session = core.get_default_session()

--- a/tests/test_db_writer.py
+++ b/tests/test_db_writer.py
@@ -11,7 +11,7 @@ from tangos import properties
 def setup():
     parallel_tasks.use('null')
 
-class DummyProperty(properties.HaloProperties):
+class DummyProperty(properties.PropertyCalculation):
     names = "dummy_property",
     requires_particle_data = True
 
@@ -22,7 +22,7 @@ class DummyProperty(properties.HaloProperties):
         return data.time*data.halo,
 
 
-class DummyPropertyCausingException(properties.HaloProperties):
+class DummyPropertyCausingException(properties.PropertyCalculation):
     names = "dummy_property_with_exception",
     requires_particle_data = True
 
@@ -78,7 +78,7 @@ def test_error_ignoring():
     assert 'dummy_property_with_exception' not in list(db.get_halo("dummy_sim_1/step.1/1").keys())
 
 
-class DummyRegionProperty(properties.HaloProperties):
+class DummyRegionProperty(properties.PropertyCalculation):
     names = "dummy_region_property",
 
     def requires_property(self):

--- a/tests/test_db_writer.py
+++ b/tests/test_db_writer.py
@@ -32,7 +32,7 @@ class DummyPropertyCausingException(properties.PropertyCalculation):
 def init_blank_simulation():
     testing.init_blank_db_for_testing(timeout=0.0)
     db.config.base = os.path.join(os.path.dirname(__file__), "test_simulations")
-    manager = add_simulation.SimulationAdderUpdater(output_testing.TestOutputSetHandler("dummy_sim_1"))
+    manager = add_simulation.SimulationAdderUpdater(output_testing.TestInputHandler("dummy_sim_1"))
     with log.LogCapturer():
         manager.scan_simulation_and_add_all_descendants()
 

--- a/tests/test_linking.py
+++ b/tests/test_linking.py
@@ -10,8 +10,8 @@ def setup():
     parallel_tasks.use('null')
     testing.init_blank_db_for_testing()
     db.config.base = os.path.join(os.path.dirname(__file__), "test_simulations")
-    manager = add_simulation.SimulationAdderUpdater(output_testing.TestOutputSetHandler("dummy_sim_1"))
-    manager2 = add_simulation.SimulationAdderUpdater(output_testing.TestOutputSetHandler("dummy_sim_2"))
+    manager = add_simulation.SimulationAdderUpdater(output_testing.TestInputHandler("dummy_sim_1"))
+    manager2 = add_simulation.SimulationAdderUpdater(output_testing.TestInputHandler("dummy_sim_2"))
     with log.LogCapturer():
         manager.scan_simulation_and_add_all_descendants()
         manager2.scan_simulation_and_add_all_descendants()

--- a/tests/test_live_calculation.py
+++ b/tests/test_live_calculation.py
@@ -47,7 +47,7 @@ def setup():
 
 
 
-class DummyProperty1(properties.HaloProperties):
+class DummyProperty1(properties.PropertyCalculation):
     names = "dummy_property_1"
 
     def plot_x0(self):
@@ -56,7 +56,7 @@ class DummyProperty1(properties.HaloProperties):
     def plot_xdelta(self):
         return 0.1
 
-class DummyProperty2(properties.HaloProperties):
+class DummyProperty2(properties.PropertyCalculation):
     names = "dummy_property_2"
 
     def plot_x0(self):
@@ -65,13 +65,13 @@ class DummyProperty2(properties.HaloProperties):
     def plot_xdelta(self):
         return 0.2
 
-class DummyPropertyArray(properties.LiveHaloProperties):
+class DummyPropertyArray(properties.LivePropertyCalculation):
     names = "dummy_property_array"
 
     def live_calculate(self, db_halo_entry, *input_values):
         return np.array([1,2,3])
 
-class DummyPropertyWithReassemblyOptions(properties.HaloProperties):
+class DummyPropertyWithReassemblyOptions(properties.PropertyCalculation):
     names = "dummy_property_with_reassembly"
 
     @classmethod
@@ -81,7 +81,7 @@ class DummyPropertyWithReassemblyOptions(properties.HaloProperties):
         else:
             return test_option
 
-class LivePropertyRequiringRedirectedProperty(properties.LiveHaloProperties):
+class LivePropertyRequiringRedirectedProperty(properties.LivePropertyCalculation):
     names = "first_BHs_BH_mass"
 
     def requires_property(self):

--- a/tests/test_property_class_mapping.py
+++ b/tests/test_property_class_mapping.py
@@ -12,22 +12,22 @@ class TestOutputHandler1Child(TestOutputHandler1):
 class TestOutputHandler2(soh.SimulationOutputSetHandler):
     pass
 
-class PropertyForHandler1(prop.HaloProperties):
+class PropertyForHandler1(prop.PropertyCalculation):
     works_with_handler = TestOutputHandler1
     requires_particle_data = True
     names = "widget", "hedgehog"
 
-class PropertyForHandler2(prop.HaloProperties):
+class PropertyForHandler2(prop.PropertyCalculation):
     works_with_handler = TestOutputHandler2
     requires_particle_data = True
     names = "widget", "robin"
 
-class PropertyForHandler1Child(prop.HaloProperties):
+class PropertyForHandler1Child(prop.PropertyCalculation):
     works_with_handler = TestOutputHandler1Child
     requires_particle_data = True
     names = "hedgehog", "satsuma"
 
-class PropertyForLiveUse(prop.LiveHaloProperties):
+class PropertyForLiveUse(prop.LivePropertyCalculation):
     names = "livewidget"
 
 def test_setup():

--- a/tests/test_property_class_mapping.py
+++ b/tests/test_property_class_mapping.py
@@ -3,13 +3,13 @@ import tangos.input_handlers as soh
 import tangos.properties as prop
 from nose.tools import assert_raises
 
-class TestOutputHandler1(soh.SimulationOutputSetHandler):
+class TestOutputHandler1(soh.HandlerBase):
     pass
 
 class TestOutputHandler1Child(TestOutputHandler1):
     pass
 
-class TestOutputHandler2(soh.SimulationOutputSetHandler):
+class TestOutputHandler2(soh.HandlerBase):
     pass
 
 class PropertyForHandler1(prop.PropertyCalculation):
@@ -49,7 +49,7 @@ def test_map_precedence():
 
 def test_map_nonexistent_name():
     with assert_raises(NameError):
-        prop.providing_class("widget", soh.SimulationOutputSetHandler)
+        prop.providing_class("widget", soh.HandlerBase)
     with assert_raises(NameError):
         prop.providing_class("robin", TestOutputHandler1)
 

--- a/tests/test_property_gathering.py
+++ b/tests/test_property_gathering.py
@@ -42,7 +42,7 @@ def setup():
             creator.link_last_halos()
             creator.link_last_bhs_using_mapping({1:1})
 
-class TestProperty(properties.LiveHaloProperties):
+class TestProperty(properties.LivePropertyCalculation):
     names = "RvirPlusMvir"
 
     def requires_property(self):
@@ -51,7 +51,7 @@ class TestProperty(properties.LiveHaloProperties):
     def live_calculate(self, halo):
         return halo["Mvir"]+halo["Rvir"]
 
-class TestErrorProperty(properties.LiveHaloProperties):
+class TestErrorProperty(properties.LivePropertyCalculation):
     names = "RvirPlusMvirMiscoded"
 
     def requires_property(self):
@@ -60,19 +60,19 @@ class TestErrorProperty(properties.LiveHaloProperties):
     def live_calculate(self, halo):
         return halo["Mvir"]+halo["Rvir"]
 
-class TestPropertyWithParameter(properties.LiveHaloProperties):
+class TestPropertyWithParameter(properties.LivePropertyCalculation):
     names = "squared"
 
     def live_calculate(self, halo, value):
         return value**2
 
-class TestBrokenProperty(properties.HaloProperties):
+class TestBrokenProperty(properties.PropertyCalculation):
     names = "brokenproperty"
 
     def __init__(self, simulation):
         raise RuntimeError("This intentionally breaks the property")
 
-class TestPathChoice(properties.LiveHaloProperties):
+class TestPathChoice(properties.LivePropertyCalculation):
     num_calls = 0
     names = "my_BH"
 

--- a/tests/test_simulation_adder.py
+++ b/tests/test_simulation_adder.py
@@ -10,15 +10,15 @@ from tangos import testing
 def setup():
     testing.init_blank_db_for_testing()
     db.config.base = os.path.join(os.path.dirname(__file__), "test_simulations")
-    manager = add_simulation.SimulationAdderUpdater(output_testing.TestOutputSetHandler("dummy_sim_1"))
+    manager = add_simulation.SimulationAdderUpdater(output_testing.TestInputHandler("dummy_sim_1"))
     with log.LogCapturer():
         manager.scan_simulation_and_add_all_descendants()
 
 def test_simulation_exists():
-    manager = add_simulation.SimulationAdderUpdater(output_testing.TestOutputSetHandler("dummy_sim_2"))
+    manager = add_simulation.SimulationAdderUpdater(output_testing.TestInputHandler("dummy_sim_2"))
     assert not manager.simulation_exists()
 
-    manager = add_simulation.SimulationAdderUpdater(output_testing.TestOutputSetHandler("dummy_sim_1"))
+    manager = add_simulation.SimulationAdderUpdater(output_testing.TestInputHandler("dummy_sim_1"))
     assert manager.simulation_exists()
 
 def test_step_halo_count():
@@ -34,7 +34,7 @@ def test_simulation_properties():
     assert db.get_simulation("dummy_sim_1")['dummy_sim_property']=='42'
 
 def test_readd_simulation():
-    manager = add_simulation.SimulationAdderUpdater(output_testing.TestOutputSetHandler("dummy_sim_1"))
+    manager = add_simulation.SimulationAdderUpdater(output_testing.TestInputHandler("dummy_sim_1"))
     with log.LogCapturer():
         manager.scan_simulation_and_add_all_descendants()
 
@@ -49,7 +49,7 @@ def _perform_simulation_update():
     try:
         old_base = db.config.base
         db.config.base = os.path.join(os.path.dirname(__file__), "test_simulations_mock_update")
-        manager = add_simulation.SimulationAdderUpdater(output_testing.TestOutputSetHandler("dummy_sim_1"))
+        manager = add_simulation.SimulationAdderUpdater(output_testing.TestInputHandler("dummy_sim_1"))
         with log.LogCapturer():
             manager.scan_simulation_and_add_all_descendants()
     finally:
@@ -69,7 +69,7 @@ def test_update_simulation():
 
 def test_renumbering():
     testing.init_blank_db_for_testing()
-    manager = add_simulation.SimulationAdderUpdater(output_testing.TestOutputSetHandlerReverseHaloNDM("dummy_sim_2"))
+    manager = add_simulation.SimulationAdderUpdater(output_testing.TestInputHandlerReverseHaloNDM("dummy_sim_2"))
     assert not manager.simulation_exists()
     with log.LogCapturer():
         manager.scan_simulation_and_add_all_descendants()
@@ -80,7 +80,7 @@ def test_renumbering():
 
 def test_renumbering_disabled():
     testing.init_blank_db_for_testing()
-    manager = add_simulation.SimulationAdderUpdater(output_testing.TestOutputSetHandlerReverseHaloNDM("dummy_sim_2"),
+    manager = add_simulation.SimulationAdderUpdater(output_testing.TestInputHandlerReverseHaloNDM("dummy_sim_2"),
                                                     renumber=False)
     assert not manager.simulation_exists()
 

--- a/tests/test_simulation_outputs.py
+++ b/tests/test_simulation_outputs.py
@@ -13,14 +13,14 @@ def setup():
     global output_manager
     testing.init_blank_db_for_testing()
     db.config.base = os.path.join(os.path.dirname(__file__), "test_simulations")
-    output_manager = pynbody_outputs.ChangaOutputSetHandler("test_tipsy")
+    output_manager = pynbody_outputs.ChangaInputHandler("test_tipsy")
 
 
 def test_get_handler():
-    assert db.input_handlers.get_named_handler_class('pynbody.ChangaOutputSetHandler') == pynbody_outputs.ChangaOutputSetHandler
+    assert db.input_handlers.get_named_handler_class('pynbody.ChangaInputHandler') == pynbody_outputs.ChangaInputHandler
 
 def test_handler_name():
-    assert pynbody_outputs.ChangaOutputSetHandler.handler_class_name()=="pynbody.ChangaOutputSetHandler"
+    assert pynbody_outputs.ChangaInputHandler.handler_class_name()=="pynbody.ChangaInputHandler"
 
 def test_enumerate():
     assert set(output_manager.enumerate_timestep_extensions())==set(["tiny.000640","tiny.000832"])

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -14,7 +14,7 @@ def setup():
     global output_manager, iord_expected_s960, iord_expected_s832
     testing.init_blank_db_for_testing()
     db.config.base = os.path.join(os.path.dirname(__file__), "test_simulations")
-    output_manager = pynbody_outputs.ChangaOutputSetHandler("test_tipsy")
+    output_manager = pynbody_outputs.ChangaInputHandler("test_tipsy")
     with log.LogCapturer():
         add.SimulationAdderUpdater(output_manager).scan_simulation_and_add_all_descendants()
 

--- a/tests/test_yt.py
+++ b/tests/test_yt.py
@@ -11,11 +11,11 @@ def setup():
     global output_manager
     testing.init_blank_db_for_testing()
     db.config.base = os.path.join(os.path.dirname(__file__), "test_simulations")
-    output_manager = yt_outputs.YtChangaAHFOutputSetHandler("test_tipsy_yt")
+    output_manager = yt_outputs.YtChangaAHFInputHandler("test_tipsy_yt")
     add.SimulationAdderUpdater(output_manager).scan_simulation_and_add_all_descendants()
 
 def test_handler():
-    assert isinstance(db.get_simulation("test_tipsy_yt").get_output_handler(), yt_outputs.YtChangaAHFOutputSetHandler)
+    assert isinstance(db.get_simulation("test_tipsy_yt").get_output_handler(), yt_outputs.YtChangaAHFInputHandler)
 
 def test_timestep():
     ts = db.get_timestep("test_tipsy_yt/tiny.000640")


### PR DESCRIPTION
In particular HaloProperties becomes PropertyCalculation which is more descriptive.

For now, the old names can still be used transparently; they can be deprecated and removed later.