### PR TITLE
Fixing broken cross linking between simulations with HOP handler

### DIFF
--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -278,11 +278,16 @@ class RamsesHOPInputHandler(PynbodyInputHandler):
     def match_objects(self, ts1, ts2, halo_min, halo_max,
                       dm_only=False, threshold=0.005, object_typetag='halo',
                       output_handler_for_ts2=None):
-        f1 = self.load_timestep(ts1).dm
-        f2 = self.load_timestep(ts2).dm
 
+        f1 = self.load_timestep(ts1).dm
         h1 = self._construct_halo_cat(ts1, object_typetag)
-        h2 = self._construct_halo_cat(ts2, object_typetag)
+
+        if output_handler_for_ts2 is None:
+            f2 = self.load_timestep(ts2).dm
+            h2 = self._construct_halo_cat(ts2, object_typetag)
+        else:
+            f2 = output_handler_for_ts2.load_timestep(ts2).dm
+            h2 = output_handler_for_ts2._construct_halo_cat(ts2, object_typetag)
 
         bridge = pynbody.bridge.OrderBridge(f1,f2, monotonic=False)
 


### PR DESCRIPTION
When calling the crosslinking between two different simulations with RAMSESHOP handler, the fact that handler number2 was different was not taken into account.

This leads to the simulation always linking with itself. I believe this should fix it.