### PR TITLE
Rollbacking something that does not exist

### DIFF
--- a/tangos/scripts/manager.py
+++ b/tangos/scripts/manager.py
@@ -291,6 +291,10 @@ def list_recent_runs(opts):
 
 def rem_run(id, confirm=True):
     run = core.get_default_session().query(Creator).filter_by(id=id).first()
+
+    if run is None:
+        raise ValueError(" Run %i does not exist" % id)
+
     print("You want to delete everything created by the following run:")
     run.print_info()
 


### PR DESCRIPTION
This is a one line change that raises a more meaningful error message if trying to rollback a calculation that does not exist.

Previously you would get
```
Traceback (most recent call last):
  File "/Users/mrey/anaconda3/bin/tangos", line 11, in <module>
    load_entry_point('tangos', 'console_scripts', 'tangos')()
  File "/Users/mrey/Documents/tangos/tangos/scripts/__init__.py", line 49, in main
    args.func(args)
  File "/Users/mrey/Documents/tangos/tangos/scripts/manager.py", line 320, in rollback
    rem_run(run_id, not options.force)
  File "/Users/mrey/Documents/tangos/tangos/scripts/manager.py", line 295, in rem_run
    run.print_info()
AttributeError: 'NoneType' object has no attribute 'print_info'
```

Now 
```
Traceback (most recent call last):
  File "/Users/mrey/anaconda3/bin/tangos", line 11, in <module>
    load_entry_point('tangos', 'console_scripts', 'tangos')()
  File "/Users/mrey/Documents/tangos/tangos/scripts/__init__.py", line 49, in main
    args.func(args)
  File "/Users/mrey/Documents/tangos/tangos/scripts/manager.py", line 324, in rollback
    rem_run(run_id, not options.force)
  File "/Users/mrey/Documents/tangos/tangos/scripts/manager.py", line 296, in rem_run
    raise ValueError(" Run %i does not exist" % id)
ValueError:  Run 4 does not exist
```