### PR TITLE
add the ability to reassemble live calculated TimeChunked quantities

### DIFF
--- a/tangos/config.py
+++ b/tangos/config.py
@@ -27,7 +27,7 @@ default_backend = 'null'
 
 
 # names of property modules to import; default is for backwards compatibility on systems with N-Body-Shop extensions
-property_modules = os.environ.get("TANGOS_PROPERTY_MODULES","tangos_nbodyshop_properties")
+property_modules = os.environ.get("TANGOS_PROPERTY_MODULES")
 property_modules = property_modules.split(",")
 property_modules = map(str.strip, property_modules)
 

--- a/tangos/core/halo_data/property.py
+++ b/tangos/core/halo_data/property.py
@@ -73,7 +73,7 @@ class HaloProperty(Base):
             cls = None
 
         if hasattr(cls, 'reassemble'):
-            return cls.reassemble(self, *options)
+            return cls.reassemble(self, self.halo, *options)
         else:
             return self.data_raw
 

--- a/tangos/live_calculation/__init__.py
+++ b/tangos/live_calculation/__init__.py
@@ -358,6 +358,8 @@ class LiveProperty(Calculation):
         super(LiveProperty, self).__init__()
         self._name = str(tokens[0])
         self._inputs = list(tokens[1:])
+        self._evaluation_pattern = '_evaluate_function'
+        self._evaluation_options= []
 
     def __str__(self):
         return self._name + "(" + (",".join(str(x) for x in self._inputs)) + ")"
@@ -384,6 +386,16 @@ class LiveProperty(Calculation):
         result = result.union(providing_instance.requires_property())
         return result
 
+    def set_evaluation_pattern(self, eval_name):
+        self._evaluation_pattern = eval_name
+
+    def set_evaluation_pattern_with_options(self,eval_name,*options):
+        self._evaluation_pattern = eval_name
+        self._evaluation_options = options
+
+    def _evaluate(self, halos, input_descriptions, input_values):
+        return getattr(self, self._evaluation_pattern)(halos, input_descriptions, input_values, *self._evaluation_options)
+
     def values_and_description(self, halos):
         input_values = []
         input_descriptions = []
@@ -392,7 +404,7 @@ class LiveProperty(Calculation):
             input_values.append(iv)
             input_descriptions.append(id)
 
-        calculator, results = self._evaluate_function(halos, input_descriptions, input_values)
+        calculator, results = self._evaluate(halos, input_descriptions, input_values)
 
         return results, calculator
 
@@ -411,6 +423,21 @@ class LiveProperty(Calculation):
         for inputs in zip(halos, *input_values):
             if self._has_required_properties(inputs[0]) and all([x is not None for x in inputs]):
                 results.append(calculator.live_calculate_named(self.name(), *inputs))
+            else:
+                results.append(None)
+        return calculator, self._as_1xn_array(results)
+
+    def _evaluate_function_with_reassemble(self, halos, input_descriptions, input_values, *options):
+        from .. import properties
+        sim = consistent_collection.consistent_simulation_from_halos(halos)
+        results = []
+        calculator = properties.providing_class(self.name())(sim, *input_descriptions)
+        for inputs in zip(halos, *input_values):
+            if self._has_required_properties(inputs[0]) and all([x is not None for x in inputs]):
+                if hasattr(calculator,'reassemble'):
+                    results.append(calculator.reassemble(self, inputs[0], *options))
+                else:
+                    results.append(calculator.live_calculate_named(self.name(), *inputs))
             else:
                 results.append(None)
         return calculator, self._as_1xn_array(results)

--- a/tangos/live_calculation/builtin_functions/reassembly.py
+++ b/tangos/live_calculation/builtin_functions/reassembly.py
@@ -1,23 +1,24 @@
 from __future__ import absolute_import
 from tangos.core import extraction_patterns
 from . import BuiltinFunction
-from .. import StoredProperty, FixedInput
+from .. import StoredProperty, FixedInput, LiveProperty
 
 
 @BuiltinFunction.register
 def raw(halos, values):
     return values
-raw.set_input_options(0, assert_class=StoredProperty)
 
 @raw.set_initialisation
 def raw_initialisation(input):
-    input.set_extraction_pattern(extraction_patterns.halo_property_raw_value_getter)
+    if isinstance(input, LiveProperty):
+        input.set_evaluation_pattern('_evaluate_function')
+    else:
+        input.set_extraction_pattern(extraction_patterns.halo_property_raw_value_getter)
 
 
 @BuiltinFunction.register
 def reassemble(halos, values, *options):
     return values
-reassemble.set_input_options(0, assert_class=StoredProperty)
 
 @reassemble.set_initialisation
 def reassemble_initialisation(input, *options):
@@ -27,6 +28,8 @@ def reassemble_initialisation(input, *options):
             options_values.append(option.proxy_value())
         else:
             raise TypeError("Options to 'reassemble' must be fixed numbers or strings")
-
-    input.set_extraction_pattern(
-        extraction_patterns.HaloPropertyValueWithReassemblyOptionsGetter(*options_values))
+    if isinstance(input,LiveProperty):
+        input.set_evaluation_pattern('_evaluate_function_with_reassemble')
+    else:
+        input.set_extraction_pattern(
+            extraction_patterns.HaloPropertyValueWithReassemblyOptionsGetter(*options_values))

--- a/tangos/properties/__init__.py
+++ b/tangos/properties/__init__.py
@@ -204,7 +204,7 @@ class TimeChunkedProperty(PropertyCalculation):
     """TimeChunkedProperty implements a special type of halo property where chunks of a histogram are stored
     at each time step, then appropriately reassembled when the histogram is retrieved."""
 
-    nbins = 2000
+    nbins = 1000
     tmax_Gyr = 20.0
     minimum_store_Gyr = 1.0
 

--- a/tangos/properties/__init__.py
+++ b/tangos/properties/__init__.py
@@ -255,7 +255,7 @@ class TimeChunkedProperty(PropertyCalculation):
         elif reassembly_type=='sum':
             return cls._reassemble_using_finding_strategy(property, halo, strategy = rfs.MultiHopAllProgenitorsStrategy)
         elif reassembly_type=='place':
-            return cls._place_data(property.halo.timestep.time_gyr, halo, property.data_raw)
+            return cls._place_data(property.halo.timestep.time_gyr, property.data_raw)
         elif reassembly_type=='raw':
             return property.data_raw
         else:

--- a/tests/test_live_calculation.py
+++ b/tests/test_live_calculation.py
@@ -75,7 +75,7 @@ class DummyPropertyWithReassemblyOptions(properties.PropertyCalculation):
     names = "dummy_property_with_reassembly"
 
     @classmethod
-    def reassemble(cls, property, test_option=25):
+    def reassemble(cls, property, halo, test_option=25):
         if test_option=='actual_data':
             return property.data_raw
         else:


### PR DESCRIPTION
Changes to LiveProperty and the reassemble functions to allow the reassembly of a live calculated TimeChunked property. Generally, this would be some function that manipulates already existing time chunked data such as SFR or SMBH accretion histories.

Also, in order to make things a bit more general, config.py does not automatically attempt to load nbodyshop properties but now only looks to the property modules defined by the environment variable. This change comes as I've had issues with this when attempting to load multiple external property modules. This also seems better as the code is now public and shouldn't be assuming anything about property modules the user wishes to load.