### PR TITLE
add new functionality to bh() 

### DIFF
--- a/tangos/properties/pynbody/BH.py
+++ b/tangos/properties/pynbody/BH.py
@@ -181,9 +181,7 @@ class BHGal(LivePropertyCalculation):
         return self._bhtype, self._bhtype+"."+self._choicep
 
     def check_constraints(self,bh):
-        print("check constraints!")
         for prop in self._constraints.keys():
-            print(self._constraints[prop], prop)
             try:
                 bh.calculate(prop)
             except:


### PR DESCRIPTION
allows user to define new constraints on the BHs they care about. So, rather than asking for the most massive or closest to center BH, they can ask for the most massive BH in a galaxy above a certain luminosity and within a certain distance from center.

The syntax works like this:

`halo.calculate("bh('BH_mass','max','BH_central','BH_mdot/BH_mass>1e-3','BH_central_distance<10')")`

The above snipped would return the most massive BH within a halo (excluding those in satellites) that has an eddington ratio above 1e-3 and is within 10 kpc from halo center.