### PR TITLE
Add ability to set a per-simulation time quantisation interval for histogram properties

### DIFF
--- a/docs/histogram_properties.md
+++ b/docs/histogram_properties.md
@@ -26,11 +26,11 @@ of the `StarFormHistogram` class:
 
 ```python
 def calculate(self, halo, _):
-    M,_ = np.histogram(halo.st['tform'].in_units("Gyr"),
-                       weights=halo.st['massform'].in_units("Msol"),
-                       bins=self.nbins,range=(0,self.tmax_Gyr))
+    tmax_Gyr = 20.0 # calculate up to 20 Gyr
+    nbins = int(20.0/self.pixel_delta_t_Gyr)
+    M,_ = np.histogram(halo.st['tform'].in_units("Gyr"),weights=weights.in_units("Msol"),bins=nbins,range=(0,tmax_Gyr))
     t_now = halo.properties['time'].in_units("Gyr")
-    M/=self.delta_t
+    M/=self.pixel_delta_t_Gyr
     M = M[self.store_slice(t_now)]
 
     return M
@@ -92,6 +92,22 @@ p.plot(halo.calculate('reassemble(SFR_histogram, "place")'),"k:")
 The differences between the default `major` reassembly and `sum` reassembly are discussed in the
 data exploration tutorial. The `place` reassembly closely tracks the `sum` reassembly back to the
 start point of the stored region, and then drops to zero.
+
+Changing the time resolution
+----------------------------
+
+By default each histogram bin is 20 Myr long. You can change this on a per-simulation basis by
+setting a simulation property. For example, for a 10 Myr time resolution for all time histograms use:
+
+```python
+sim = tangos.get_simulation("my_sim")
+sim["histogram_delta_t_Gyr"] = 0.01
+```
+
+Note that it is a _very_ bad idea to change this after you have already written some time histograms
+for a simulation. You will almost certainly end up getting inconsistent results. Always set `histogram_delta_t_Gyr`
+before your first `tangos write`.
+
 
 Exercising caution
 -------------------

--- a/tangos/core/halo_data/property.py
+++ b/tangos/core/halo_data/property.py
@@ -73,7 +73,8 @@ class HaloProperty(Base):
             cls = None
 
         if hasattr(cls, 'reassemble'):
-            return cls.reassemble(self, *options)
+            instance = cls(self.halo.timestep.simulation)
+            return instance.reassemble(self, *options)
         else:
             return self.data_raw
 

--- a/tangos/properties/__init__.py
+++ b/tangos/properties/__init__.py
@@ -203,30 +203,27 @@ class TimeChunkedProperty(PropertyCalculation):
     """TimeChunkedProperty implements a special type of halo property where chunks of a histogram are stored
     at each time step, then appropriately reassembled when the histogram is retrieved."""
 
-    nbins = 1000
-    tmax_Gyr = 20.0
-    minimum_store_Gyr = 1.0
+    pixel_delta_t_Gyr = 0.02  # default value. Can be overriden by a simulation property histogram_delta_t_Gyr
+    minimum_store_Gyr = 0.5
 
-    @property
-    def delta_t(self):
-        return self.tmax_Gyr/self.nbins
+    def __init__(self, simulation):
+        self.pixel_delta_t_Gyr = simulation.get("histogram_delta_t_Gyr", self.pixel_delta_t_Gyr)
+        super(TimeChunkedProperty, self).__init__(simulation)
 
-    @classmethod
+
     def bin_index(self, time):
         """Convert a time (Gyr) to a bin index in the histogram"""
-        index = int(self.nbins*time/self.tmax_Gyr)
+        index = int(time/self.pixel_delta_t_Gyr)
         if index<0:
             index = 0
         return index
 
-    @classmethod
     def store_slice(self, time):
         """Tells subclasses which have generated a histogram over all time which slice of that histogram
         they should store."""
         return slice(self.bin_index(time-self.minimum_store_Gyr), self.bin_index(time))
 
-    @classmethod
-    def reassemble(cls, property, reassembly_type='major'):
+    def reassemble(self, property, reassembly_type='major'):
         """Reassemble a histogram by suitable treatment of the merger tree leading up to the current halo.
 
         This function is normally called by the framework (see Halo.get_data_with_reassembly_options) and you would
@@ -247,36 +244,34 @@ class TimeChunkedProperty(PropertyCalculation):
         from tangos import relation_finding as rfs
 
         if reassembly_type=='major':
-            return cls._reassemble_using_finding_strategy(property, strategy = rfs.MultiHopMajorProgenitorsStrategy)
+            return self._reassemble_using_finding_strategy(property, strategy = rfs.MultiHopMajorProgenitorsStrategy)
         elif reassembly_type=='major_across_simulations':
-            return cls._reassemble_using_finding_strategy(property, strategy = rfs.MultiHopMajorProgenitorsStrategy,
-                                                          strategy_kwargs = {'target': None})
+            return self._reassemble_using_finding_strategy(property, strategy = rfs.MultiHopMajorProgenitorsStrategy,
+                                                           strategy_kwargs = {'target': None})
         elif reassembly_type=='sum':
-            return cls._reassemble_using_finding_strategy(property, strategy = rfs.MultiHopAllProgenitorsStrategy)
+            return self._reassemble_using_finding_strategy(property, strategy = rfs.MultiHopAllProgenitorsStrategy)
         elif reassembly_type=='place':
-            return cls._place_data(property.halo.timestep.time_gyr, property.data_raw)
+            return self._place_data(property.halo.timestep.time_gyr, property.data_raw)
         elif reassembly_type=='raw':
             return property.data_raw
         else:
             raise ValueError("Unknown reassembly type")
 
-    @classmethod
-    def _place_data(cls, time, raw_data):
-        final = np.zeros(cls.bin_index(time))
+    def _place_data(self, time, raw_data):
+        final = np.zeros(self.bin_index(time))
         end = len(final)
         start = end - len(raw_data)
         final[start:] = raw_data
         return final
 
-    @classmethod
-    def _reassemble_using_finding_strategy(cls, property, strategy, strategy_kwargs={}):
+    def _reassemble_using_finding_strategy(self, property, strategy, strategy_kwargs={}):
         name = property.name.text
         halo = property.halo
         t, stack = halo.calculate_for_descendants("t()", "raw(" + name + ")", strategy=strategy, strategy_kwargs=strategy_kwargs)
-        final = np.zeros(cls.bin_index(t[0]))
+        final = np.zeros(self.bin_index(t[0]))
         previous_time = -1
         for t_i, hist_i in zip(t, stack):
-            end = cls.bin_index(t_i)
+            end = self.bin_index(t_i)
             start = end - len(hist_i)
             valid = hist_i == hist_i
             if t_i != previous_time:
@@ -289,13 +284,13 @@ class TimeChunkedProperty(PropertyCalculation):
         return final
 
 
-    def plot_xdelta(cls):
-        return cls.tmax_Gyr/cls.nbins
+    def plot_xdelta(self):
+        return self.pixel_delta_t_Gyr
 
-    def plot_xlog(cls):
+    def plot_xlog(self):
         return False
 
-    def plot_ylog(cls):
+    def plot_ylog(self):
         return False
 
 

--- a/tangos/properties/__init__.py
+++ b/tangos/properties/__init__.py
@@ -201,7 +201,9 @@ HaloProperties = PropertyCalculation # old name, to be deprecated
 
 class TimeChunkedProperty(PropertyCalculation):
     """TimeChunkedProperty implements a special type of halo property where chunks of a histogram are stored
-    at each time step, then appropriately reassembled when the histogram is retrieved."""
+    at each time step, then appropriately reassembled when the histogram is retrieved.
+
+    For more information see docs/histogram_properties.md"""
 
     pixel_delta_t_Gyr = 0.02  # default value. Can be overriden by a simulation property histogram_delta_t_Gyr
     minimum_store_Gyr = 0.5

--- a/tangos/properties/pynbody/BH.py
+++ b/tangos/properties/pynbody/BH.py
@@ -116,7 +116,10 @@ class BHAccHistogram(TimeChunkedProperty):
         order = np.argsort(t_orbit)
 
         t_max = properties.timestep.time_gyr
-        t_grid = np.linspace(0, self.tmax_Gyr, self.nbins)
+
+        grid_tmax_Gyr = 20.0
+        nbins = grid_tmax_Gyr/self.pixel_delta_t_Gyr
+        t_grid = np.linspace(0, grid_tmax_Gyr, nbins)
 
         Mdot_grid = scipy.interpolate.interp1d(t_orbit[order], Mdot_orbit[order], bounds_error=False)(t_grid)
 

--- a/tangos/properties/pynbody/SF.py
+++ b/tangos/properties/pynbody/SF.py
@@ -22,14 +22,17 @@ class StarFormHistogram(TimeChunkedProperty):
             weights = halo.st['massform']
         except KeyError:
             weights = halo.st['mass']
-        M,_ = np.histogram(halo.st['tform'].in_units("Gyr"),weights=weights.in_units("Msol"),bins=self.nbins,range=(0,self.tmax_Gyr))
+
+        tmax_Gyr = 20.0 # calculate up to 20 Gyr
+        nbins = int(20.0/self.pixel_delta_t_Gyr)
+
+        M,_ = np.histogram(halo.st['tform'].in_units("Gyr"),weights=weights.in_units("Msol"),bins=nbins,range=(0,tmax_Gyr))
         t_now = halo.properties['time'].in_units("Gyr")
-        M/=self.delta_t
+        M/=self.pixel_delta_t_Gyr
         M = M[self.store_slice(t_now)]
 
         return M
 
-    @classmethod
-    def reassemble(cls, *options):
+    def reassemble(self, *options):
         reassembled = TimeChunkedProperty.reassemble(*options)
         return reassembled/1e9 # Msol per Gyr -> Msol per yr

--- a/tangos/scripts/manager.py
+++ b/tangos/scripts/manager.py
@@ -19,6 +19,7 @@ from tangos.core.tracking import TrackData
 from tangos.query import get_simulation, get_halo
 from tangos.input_handlers import get_named_handler_class
 from tangos.tools.add_simulation import SimulationAdderUpdater
+from tangos.log import logger
 from six.moves import input
 
 
@@ -78,53 +79,74 @@ def _db_import_export(target_session, from_session, *sims):
     for sim in sims:
         ext_sim = get_simulation(sim, from_session)
         sim = Simulation(ext_sim.basename)
-        heading("import " + repr(ext_sim))
         sim = target_session.merge(sim)
+        logger.info("Transferring simulation %s", ext_sim)
 
+        halos_this_ts = []
         for p_ext in ext_sim.properties:
             dic = get_or_create_dictionary_item(
                 target_session, p_ext.name.text)
             p = SimulationProperty(sim, dic, p_ext.data)
-            p = target_session.merge(p)
+            halos_this_ts.append(p)
 
         for tk_ext in ext_sim.trackers:
             tk = TrackData(sim, tk_ext.halo_number)
             tk.particles = tk_ext.particles
             tk.use_iord = tk_ext.use_iord
+            halos_this_ts.append(tk)
+
+        target_session.add_all(halos_this_ts)
 
         for ts_ext in ext_sim.timesteps:
-            print(".", end=' ')
-            sys.stdout.flush()
-            ts = TimeStep(sim, ts_ext.extension, False)
+            logger.info("Transferring timestep %s",ts_ext)
+            ts = TimeStep(sim, ts_ext.extension)
             ts.redshift = ts_ext.redshift
             ts.time_gyr = ts_ext.time_gyr
             ts.available = True
             ts = target_session.merge(ts)
-            for h_ext in ts_ext.halos:
+
+            halos_this_ts = []
+
+            logger.info("Transferring objects for %s", ts_ext)
+            for h_ext in ts_ext.objects:
                 h = Halo(ts, h_ext.halo_number, h_ext.finder_id, h_ext.NDM,
                          h_ext.NStar, h_ext.NGas, h_ext.object_typecode)
-                h = target_session.merge(h)
+                h.external_id = h_ext.id
+                halos_this_ts.append(h)
+
+            target_session.add_all(halos_this_ts)
+            target_session.commit()
+
+            for h in halos_this_ts:
                 assert h.id is not None and h.id > 0
-                external_to_internal_halo_id[h_ext.id] = h.id
+                external_to_internal_halo_id[h.external_id] = h.id
+
+            properties_this_ts = []
+            logger.info("Transferring object properties for %s", ts_ext)
+            for h_ext in ts_ext.objects:
+                h_new_id = external_to_internal_halo_id[h_ext.id]
                 for p_ext in h_ext.properties:
                     dic = get_or_create_dictionary_item(
                         target_session, p_ext.name.text)
-                    dat = p_ext.data
+                    dat = p_ext.data_raw
                     if dat is not None:
-                        p = HaloProperty(h, dic, dat)
-                        p = target_session.merge(p)
+                        p = HaloProperty(h_new_id, dic, dat)
+                        properties_this_ts.append(p)
 
-        print("Translate halolinks", end=' ')
+            target_session.add_all(properties_this_ts)
+            target_session.commit()
+
         for ts_ext in ext_sim.timesteps:
-            print(".", end=' ')
+            logger.info("Transferring halolinks for timestep %s", ts_ext)
             sys.stdout.flush()
             _translate_halolinks(
                 target_session, ts_ext.links_from, external_to_internal_halo_id, translated_halolink_ids)
             _translate_halolinks(
                 target_session, ts_ext.links_to, external_to_internal_halo_id, translated_halolink_ids)
+            target_session.commit()
 
-        print("Done")
-        target_session.commit()
+        logger.info("Done")
+
 
 
 def _translate_halolinks(target_session, halolinks, external_to_internal_halo_id, translated):
@@ -134,7 +156,7 @@ def _translate_halolinks(target_session, halolinks, external_to_internal_halo_id
 
         dic = get_or_create_dictionary_item(
             target_session, hl_ext.relation.text)
-        hl_new = HaloLink(None, None, dic)
+        hl_new = target_session.merge(HaloLink(None, None, dic))
 
         try:
             hl_new.halo_from_id = external_to_internal_halo_id[
@@ -146,7 +168,7 @@ def _translate_halolinks(target_session, halolinks, external_to_internal_halo_id
             hl_new.halo_to_id = external_to_internal_halo_id[hl_ext.halo_to_id]
         except KeyError:
             continue
-        target_session.add(hl_new)
+
         translated.append(hl_ext.id)
 
 
@@ -428,6 +450,7 @@ def get_argument_parser_and_subparsers():
     subparse_remruns = subparse.add_parser("rm", help="Remove a simulation from the database")
     subparse_remruns.add_argument("sims", help="The path to the simulation folder relative to the database folder")
     subparse_remruns.set_defaults(func=rem_simulation_timesteps)
+     """
     
     subparse_import = subparse.add_parser("import",
                                           help="Import one or more simulations from another sqlite file")
@@ -435,7 +458,7 @@ def get_argument_parser_and_subparsers():
     subparse_import.add_argument("sims", nargs="*", type=str,
                                  help="The name of the simulations to import (or import everything if none specified)")
     subparse_import.set_defaults(func=db_import)
-    """
+
 
 
     subparse_deprecate = subparse.add_parser("flag-duplicates",

--- a/tangos/scripts/manager.py
+++ b/tangos/scripts/manager.py
@@ -69,11 +69,10 @@ def db_export(remote_db, *sims):
 
 
 def _db_import_export(target_session, from_session, *sims):
-    from tangos.util.terminalcontroller import heading
     external_to_internal_halo_id = {}
     translated_halolink_ids = []
 
-    if sims == tuple():
+    if len(sims)==0:
         sims = [x.id for x in all_simulations(from_session)]
 
     for sim in sims:

--- a/tangos/testing/__init__.py
+++ b/tangos/testing/__init__.py
@@ -148,8 +148,9 @@ def init_blank_db_for_testing(**init_kwargs):
 
     caller_fname = os.path.basename(inspect.getframeinfo(inspect.currentframe().f_back)[0])[:-3]
 
-    print(caller_fname)
-    db_name = "test_dbs/%s.db"%caller_fname
+    testing_db_name = init_kwargs.pop("testing_db_name", caller_fname)
+
+    db_name = "test_dbs/%s.db"%testing_db_name
     try:
 
         os.remove(db_name)

--- a/tangos/testing/db_diff.py
+++ b/tangos/testing/db_diff.py
@@ -2,18 +2,24 @@ from .. import core, all_simulations, get_simulation, get_timestep, get_object
 from ..log import logger
 import six
 import numpy.testing as npt
-from sqlalchemy.orm import joinedload, object_session, undefer
+from sqlalchemy.orm import joinedload, object_session, undefer, Session
 
 class TangosDbDiff(object):
     """Class to compare two databases, used by the tangos diff command line tool"""
 
     def __init__(self, uri1, uri2, max_objects=10):
-        core.init_db(uri1)
-        self.session1 = core.get_default_session()
-        self.uri1 = uri1
-        core.init_db(uri2)
-        self.session2 = core.get_default_session()
-        self.uri2 = uri2
+        if isinstance(uri1, Session):
+            self.session1 = uri1
+        else:
+            core.init_db(uri1)
+            self.session1 = core.get_default_session()
+
+
+        if isinstance(uri2, Session):
+            self.session2 = uri2
+        else:
+            core.init_db(uri2)
+            self.session2 = core.get_default_session()
 
         self.test_simulations = True
         self.test_timesteps = True

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,37 @@
+import tangos, tangos.testing as testing, tangos.scripts.manager as manager
+import tangos.testing.simulation_generator
+import tangos.testing.db_diff as diff
+
+def setup():
+    testing.init_blank_db_for_testing()
+
+    creator = tangos.testing.simulation_generator.TestSimulationGenerator()
+
+    halo_offset = 0
+    for ts in range(1,4):
+        num_halos = 4 if ts<3 else 3
+        creator.add_timestep()
+        creator.add_objects_to_timestep(num_halos)
+        creator.add_properties_to_halos(Mvir=lambda i: i+halo_offset)
+        creator.add_properties_to_halos(Rvir=lambda i: (i+halo_offset)*0.1)
+        halo_offset+=num_halos
+
+        creator.add_bhs_to_timestep(4)
+        creator.add_properties_to_bhs(hole_mass = lambda i: float(i*100))
+        creator.add_properties_to_bhs(hole_spin = lambda i: 1000-float(i)*100)
+
+        creator.assign_bhs_to_halos({1:1, 2:2, 3:3, 4:3})
+
+
+        if ts>1:
+            creator.link_last_halos()
+            creator.link_last_bhs_using_mapping({1:1})
+
+def test_import():
+    existing_session = tangos.get_default_session()
+    testing.init_blank_db_for_testing(testing_db_name='imported_db_test')
+    new_session = tangos.get_default_session()
+    manager._db_import_export(new_session, existing_session)
+    differ = diff.TangosDbDiff(existing_session, new_session)
+    differ.compare()
+    assert not differ.failed, "Copied database differs; see log for details"


### PR DESCRIPTION
This PR addresses the need for user-defined time quantisation in the histogram properties (i.e. `SFR_histogram` and `BH_mdot_histogram`). @mtremmel had manually modified his local copy to make finer time bins, leading to incompatibility when his databases were read by other users.

Users can now set a simulation property, `histogram_delta_t_Gyr`, and the properties will automatically adopt that as the quantisation interval. This does come with the caveat that changing `histogram_delta_t_Gyr` after already calculating some histogram properties will lead to severe confusion.