### PR TITLE
Remove unnecessary SQL query within MultiSourceMultiHopStrategy

### DIFF
--- a/tangos/relation_finding/multi_source.py
+++ b/tangos/relation_finding/multi_source.py
@@ -75,9 +75,6 @@ class MultiSourceMultiHopStrategy(MultiHopStrategy):
         self._connection.execute(self._table.insert(), insert_dictionaries)
 
     def _generate_next_level_prelim_links(self, from_nhops=0):
-        all = self.session.query(self._link_orm_class).filter(self._link_orm_class.halo_to_id!=self._link_orm_class.halo_from_id).all()
-        source_ids = [x.source_id for x in all]
-        num_sources = len(self._all_halo_from)
         if self._should_halt():
             return 0
         else:


### PR DESCRIPTION
This query was taking up to 90% of the execution time and had no effect. It was probably a left-over residual from a previous version of the algorithm.