### PR TITLE
Button to download a merger tree 

### DIFF
--- a/tangos/web/static/mergertree.js
+++ b/tangos/web/static/mergertree.js
@@ -105,6 +105,7 @@ function buildTree(containerName, treeData, customOptions)
         .append("svg:path")
         .attr("class", "link")
         .attr("d", link)
+        .style("stroke", "#a8aaa6")
         .style("stroke-width", function(d) {
                 return Math.min(d.source.size, d.target.size)*1.3;
             })
@@ -130,6 +131,7 @@ function buildTree(containerName, treeData, customOptions)
         .enter()
         .append("svg:g")
         .attr("class", "node")
+        .style("fill", "#aa161f")
         .attr("transform", function(d)
         {
             return "translate(" + d.y + "," + d.x + ")";

--- a/tangos/web/static/mergertree.js
+++ b/tangos/web/static/mergertree.js
@@ -105,6 +105,7 @@ function buildTree(containerName, treeData, customOptions)
         .append("svg:path")
         .attr("class", "link")
         .attr("d", link)
+        .attr("fill", "none")
         .style("stroke", "#a8aaa6")
         .style("stroke-width", function(d) {
                 return Math.min(d.source.size, d.target.size)*1.3;

--- a/tangos/web/templates/halo_view.jinja2
+++ b/tangos/web/templates/halo_view.jinja2
@@ -66,6 +66,7 @@
             <input name="logy" type="checkbox" id="logy"/><label for="logy">log y</label>
             <input name="logimage" type="checkbox" id="logimage"/><label for="logimage">log images</label>.
             <a href="#" id="download-csv-link">&#x25BC; Download CSV</a>
+            <a href="#" id="download-merger-tree">&#x25BC; Download Merger Tree</a>
         </form>
         </div>
         <div id="imgbox"></div>
@@ -240,6 +241,11 @@
                 treeError();
             });
 
+            d3.select("#download-merger-tree").on("click", function(){
+               d3.select(this)
+                    .attr("href", 'data:image/svg+xml;base64,' + btoa(d3.select("#imgbox").html()))
+                   .attr("download", "merger_tree.svg")
+            })
         }
 
         function fetchPlot(isUpdate)


### PR DESCRIPTION
I have added a feature to the web interface to save merger trees as svg files and being able to import them in Inkscape for example. Below are three screenshots to show what the addition looks like and how it renders into Inkscape.

I had to directly input some styles (colours etc) for some svg element pdf of the merger tree. Otherwise they would not be visible when downloaded. I tested that the download works in Safari and in Chrome.

The downloaded rendering is not perfect, the visual links of the merger tree (which can be wavy) are actually over plotted with straight links. I don't know yet whether this is worth fixing in place or directly with svg tools.

All comments welcome as reliably exporting svg from webpages is actually a lot more subtle and problematic than it seems. Tons of SO questions cover this problem, most with different answers.


![screen shot 2018-06-19 at 15 26 29](https://user-images.githubusercontent.com/22526234/41603650-595ef704-73d5-11e8-918a-ba76ace48714.png)

![screen shot 2018-06-19 at 15 02 37](https://user-images.githubusercontent.com/22526234/41603690-6307607a-73d5-11e8-8b3a-4dcc1e4b1451.png)


![screen shot 2018-06-19 at 15 25 43](https://user-images.githubusercontent.com/22526234/41603539-1637896e-73d5-11e8-9f72-089d02b0082f.png)