### PR TITLE
Fix issue in BH merger timelink causing runs to consistently fail

### DIFF
--- a/tangos/scripts/add_bh.py
+++ b/tangos/scripts/add_bh.py
@@ -275,7 +275,8 @@ def generate_halolinks(session, fname, pairs):
         with session.no_autoflush:
             for src,(dest,ratio) in six.iteritems(bh_map):
                 if src not in nums1 or dest not in nums2:
-                    logger.warn("Can't link BH %r -> %r; missing BH objects in database",nums1,nums2)
+                    logger.warn("Can't link BH %r -> %r; missing BH objects in database",src,dest)
+                    continue
                 bh_src_before = bh_objects_1[nums1.index(src)]
                 bh_dest_after = bh_objects_2[nums2.index(dest)]
 


### PR DESCRIPTION
If either of two BHs that have been tagged as merging do not exist in the database, write out the warning message, but then ignore the merger and move on, rather than hitting an error which kills the entire run. This can occur very commonly at early times when black holes are likely to exist in very small halos no included in the database (or not even resolved/captured by the halo finder). The warning message has also been adapted to only include the two BH id numbers of the failed connection, rather than the total list of BH pairs, which is much less informative.