### PR TITLE
Fix calculations raising exceptions instead of returning empty results

### DIFF
--- a/tangos/live_calculation/__init__.py
+++ b/tangos/live_calculation/__init__.py
@@ -393,6 +393,8 @@ class LiveProperty(Calculation):
         return result
 
     def values_and_description(self, halos):
+        if len(halos)==0:
+            return np.array([[]]), None
         input_values = []
         input_descriptions = []
         for input in range(len(self._inputs)):
@@ -588,9 +590,6 @@ class Link(Calculation):
         mask = QueryMask()
         mask.mark_nones_as_masked(target_halos)
         target_halo_masked = mask.mask(target_halos)
-
-        if len(target_halo_masked)==0:
-            raise NoResultsError("No results found when attempting to follow link %r"%self.locator)
 
         if self._expect_multivalues:
             if self._multi_selection_basis=='first':

--- a/tangos/util/consistent_collection.py
+++ b/tangos/util/consistent_collection.py
@@ -6,6 +6,8 @@ class ConsistentCollection(object):
     returns a different value, a ValueError is raised."""
 
     def __init__(self, objects):
+        if len(objects)==0:
+            raise ValueError("Cannot create a ConsistentCollection from an empty list")
         self._objects = set(objects)
 
     def __getitem__(self, item):

--- a/tests/test_consistent_collection.py
+++ b/tests/test_consistent_collection.py
@@ -54,3 +54,7 @@ def test_set_pruning():
 def test_generate_from_halos():
     col2 = cc.consistent_simulation_from_halos([h1,h2,h2])
     assert col2['consistent_property']==1.0
+
+def test_empty_collection():
+    with assert_raises(ValueError):
+        col = cc.ConsistentCollection([])

--- a/tests/test_live_calculation.py
+++ b/tests/test_live_calculation.py
@@ -234,3 +234,10 @@ def test_calculate_preserves_numpy_dtype():
 def test_empty_timestep_live_calculation():
     vals, = tangos.get_timestep("sim/ts3").calculate_all("BH_mass")
     assert len(vals)==0
+
+
+def test_non_existent_redirection_multihalo():
+    # See issue #46
+    vals1, vals2 = tangos.get_timestep("sim/ts3").calculate_all("BH_mass","later(1).BH_mass")
+    assert len(vals1)==0
+    assert len(vals2)==0


### PR DESCRIPTION
This was caused by creating an empty ConsistentCollection in some
circumstances. Prevent this from happening, and add explicit test to
ConsistentCollection that it is not called with an empty set (since it is
impossible to define sensible behaviour in that case).