### PR TITLE
Unreliable contamination_fraction calculation

### DIFF
--- a/tangos/properties/pynbody/zoom.py
+++ b/tangos/properties/pynbody/zoom.py
@@ -15,14 +15,20 @@ class Contamination(PynbodyPropertyCalculation):
     def calculate(self, halo, exist):
         loaded_data_min_dm_mass = halo.dm['mass'].min()
 
-        # If mass resolution not present as a property, ensure backward compatibility by setting the min mass to infinity
+        # If mass resolution is not present as a simulation property,
+        # ensure backward compatibility by setting the min mass to infinity
         import numpy as np
-        simulation_min_dm_mass = self._simulation.get("approx_resolution_Msol", default=np.inf)
+        import pynbody.array as array
+        simulation_min_dm_mass = array.SimArray(self._simulation.get("approx_resolution_Msol", default=np.inf),
+                                                units="Msol")
 
-        if loaded_data_min_dm_mass > simulation_min_dm_mass:
-            # Loaded data contains only "heavy" particles, e.g. an unzoomed halo in server mode
-                return 1.0
-        else:
-            # Loaded data contains heavy and/or light particles, e.g
+        if np.isclose(loaded_data_min_dm_mass, simulation_min_dm_mass, rtol=1e-1, atol=1):
+            # Loaded data contains some light particles. Tolerance of this test (agreement to 10% or to 1 Msol)
+            # is sufficiently tight to separate heavy and light resolution,
+            # while being broad enough to capture numerical inaccuracies coming
+            # from the simulation mass resolution.
             n_heavy = (halo.dm['mass'] > loaded_data_min_dm_mass).sum()
             return float(n_heavy) / len(halo.dm)
+        else:
+            # Loaded data contains only "heavy" particles, e.g. an unzoomed halo in server mode
+            return 1.0


### PR DESCRIPTION
Hi,

Following the update in #91 , I have played around a bit more with the new contamination_fraction. One problem is that the test introduced here:
https://github.com/pynbody/tangos/blob/decab8c892c5937fd68474a375089abef198dba2/tangos/properties/pynbody/zoom.py#L22-L25
introduced to deal with #85 is subject to numerical inaccuracies. It have seen it evaluate to True  because the simulation mass property was 1e-7 smaller than the loaded minimal mass.

This PR is a proposed change to make this test more robust. I would be happy to modify it if better suggestions arise.

Martin