### PR TITLE
Fix ambiguity in identifying the major progenitor branch

### DIFF
--- a/tangos/examples/mergers.py
+++ b/tangos/examples/mergers.py
@@ -16,7 +16,7 @@ def get_mergers_of_major_progenitor(input_halo):
     ratio = []
     halo  = []
     while input_halo is not None:
-        mergers = db.relation_finding.MultiHopMostRecentMergerStrategy(input_halo).all()
+        mergers = db.relation_finding.MultiHopMostRecentMergerStrategy(input_halo, order_by='weight').all()
         if len(mergers)>0 :
             for m in mergers[1:]:
                 redshift.append(mergers[0].timestep.next.redshift)

--- a/tangos/testing/__init__.py
+++ b/tangos/testing/__init__.py
@@ -20,6 +20,8 @@ def _as_halos(hlist, session=None):
             rvals.append(None)
         elif isinstance(h, core.halo.Halo):
             rvals.append(h)
+        elif isinstance(h, list) or isinstance(h, tuple):
+            rvals.append(_as_halos(h, session))
         else:
             rvals.append(get_halo(h, session))
     return rvals
@@ -28,7 +30,15 @@ def _halos_to_strings(hlist):
     if len(hlist)==0:
         return "(empty list)"
     else:
-        return str([hx.path if hx else "None" for hx in _as_halos(hlist)])
+        strlist = []
+        for h in hlist:
+            if isinstance(h, list) or isinstance(h, tuple):
+                strlist.append(_halos_to_strings(h))
+            elif isinstance(h,str):
+                strlist.append(h)
+            else:
+                strlist.append(h.path)
+        return str(strlist)
 
 def halolists_equal(hl1, hl2, session=None):
     """Return True if hl1 and hl2 are equivalent lists of halos"""

--- a/tangos/testing/simulation_generator.py
+++ b/tangos/testing/simulation_generator.py
@@ -91,7 +91,7 @@ class TestSimulationGenerator(object):
         self._generate_bidirectional_halolinks_for_mapping(mapping, ts_dest, ts_source, object_typecode)
         self.session.commit()
 
-    def link_last_halos(self, object_typecode=0):
+    def link_last_halos(self, object_typecode=0, consistent_masses=False):
         """Generate default halolinks for the most recent two timesteps such that 1->1, 2->2 etc"""
         if len(self.sim.timesteps)<2:
             return
@@ -100,7 +100,7 @@ class TestSimulationGenerator(object):
         halo_nums_dest = set([a.halo_number for a in ts_dest.objects.filter_by(object_typecode=object_typecode).all()])
         halo_nums_common = halo_nums_source.intersection(halo_nums_dest)
         mapping = dict([(a,a) for a in halo_nums_common])
-        self.link_last_halos_using_mapping(mapping,False, object_typecode)
+        self.link_last_halos_using_mapping(mapping,consistent_masses, object_typecode)
 
 
     def link_last_bhs(self):
@@ -132,7 +132,7 @@ class TestSimulationGenerator(object):
         self._generate_bidirectional_halolinks_for_mapping(mapping, ts_dest, ts_source, object_typecode)
         self.session.commit()
 
-    def add_mass_transfer(self, source_num, target_num, fraction_of_source, object_typecode=0):
+    def add_mass_transfer(self, source_num, target_num, fraction_of_source, object_typecode=0, adjust_masses=False):
         ts_source, ts_dest = self._two_most_recently_added_timesteps()
         source_halo = ts_source.objects.filter_by(halo_number=source_num, object_typecode=object_typecode).first()
         target_halo = ts_dest.objects.filter_by(halo_number=target_num, object_typecode=object_typecode).first()
@@ -141,8 +141,18 @@ class TestSimulationGenerator(object):
         fraction_of_dest = float(transferred_ptcls)/target_halo.NDM
         ts_source, ts_dest = self._two_most_recently_added_timesteps()
 
+        if adjust_masses:
+            target_halo.NDM+=source_halo.NDM * fraction_of_source
+            major_descendant = source_halo.next
+            if major_descendant:
+                major_descendant.NDM-=source_halo.NDM * fraction_of_source
+
         forward_link = core.halo_data.HaloLink(source_halo, target_halo, self._ptcls_in_common_dict, fraction_of_source)
         backward_link = core.halo_data.HaloLink(target_halo, source_halo, self._ptcls_in_common_dict, fraction_of_dest)
+
+        self.session.add_all([forward_link, backward_link])
+        self.session.commit()
+
 
 
     def _generate_bidirectional_halolinks_for_mapping(self, mapping, ts_dest, ts_source, object_typecode):

--- a/tangos/testing/simulation_generator.py
+++ b/tangos/testing/simulation_generator.py
@@ -80,18 +80,18 @@ class TestSimulationGenerator(object):
 
         return ts
 
-    def link_last_halos_using_mapping(self, mapping, consistent_masses=True, object_typecode=0) :
+    def link_last_halos_using_mapping(self, mapping, adjust_masses=True, object_typecode=0) :
         """Store halolinks such that ts_source[halo_i].next = ts_dest[mapping[halo_i]]
 
         :type mapping dict"""
 
         ts_source, ts_dest = self._two_most_recently_added_timesteps()
-        if consistent_masses:
+        if adjust_masses:
             self._adjust_halo_NDM_for_mapping(mapping, ts_dest, ts_source)
         self._generate_bidirectional_halolinks_for_mapping(mapping, ts_dest, ts_source, object_typecode)
         self.session.commit()
 
-    def link_last_halos(self, object_typecode=0, consistent_masses=False):
+    def link_last_halos(self, object_typecode=0, adjust_masses=False):
         """Generate default halolinks for the most recent two timesteps such that 1->1, 2->2 etc"""
         if len(self.sim.timesteps)<2:
             return
@@ -100,7 +100,7 @@ class TestSimulationGenerator(object):
         halo_nums_dest = set([a.halo_number for a in ts_dest.objects.filter_by(object_typecode=object_typecode).all()])
         halo_nums_common = halo_nums_source.intersection(halo_nums_dest)
         mapping = dict([(a,a) for a in halo_nums_common])
-        self.link_last_halos_using_mapping(mapping,consistent_masses, object_typecode)
+        self.link_last_halos_using_mapping(mapping,adjust_masses, object_typecode)
 
 
     def link_last_bhs(self):

--- a/tests/test_difficult_merger_scenario.py
+++ b/tests/test_difficult_merger_scenario.py
@@ -1,0 +1,75 @@
+"""This test is for a specific merger scenario where a halo partially merges (i.e. is heavily stripped)
+but survives; and then the remnant potentially merges later on.
+
+Further difficult scenarios could be added here in future and tested against various tools"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+import tangos.core.dictionary
+import tangos.core.halo
+import tangos.core.halo_data
+import tangos.core.simulation
+import tangos.core.timestep
+import tangos
+import tangos.testing.simulation_generator
+
+from tangos.relation_finding import tree
+import tangos.testing as testing
+import numpy as np
+
+def setup():
+    testing.init_blank_db_for_testing()
+
+    generator = tangos.testing.simulation_generator.TestSimulationGenerator()
+    generator.add_timestep() # ts1
+    generator.add_objects_to_timestep(2, NDM=[1000,600])
+
+    generator.add_timestep() # ts2
+    generator.add_objects_to_timestep(2)
+    generator.link_last_halos(consistent_masses=True)
+
+    generator.add_timestep() # ts3, in which halo 1 and 2 collide
+    generator.add_objects_to_timestep(2)
+    generator.link_last_halos_using_mapping({1:2, 2:1}, consistent_masses=True) # halo 1 becomes 2, 2 becomes 1 due to mass ordering
+    generator.add_mass_transfer(1,1,0.3, adjust_masses=True) # halo 1 in previous step loses 30% of its mass to halo 1 in this step... but survives
+
+    generator.add_timestep() # ts4
+    generator.add_objects_to_timestep(2)
+    generator.link_last_halos(consistent_masses=True)
+    generator.add_mass_transfer(2,1,0.05, adjust_masses=True) # continued minor stripping of halo 2
+
+    generator.add_timestep() #ts5, in which halo 1 and 2 finally merge completely
+    generator.add_objects_to_timestep(1)
+    generator.link_last_halos_using_mapping({1:1, 2:1}, consistent_masses=True)
+
+def test_setup():
+    ndm_test = [[x.NDM for x in tangos.get_timestep(ts).halos] for ts in range(1,6)]
+    assert np.all(ndm_test[0] == [1000, 600])
+    assert np.all(ndm_test[1] == [1000, 600])
+    assert np.all(ndm_test[2] == [900, 700])
+    assert np.all(ndm_test[3] == [935, 665])
+    assert np.all(ndm_test[4] == [1600])
+
+def test_major_progenitor_branch():
+    halo_num, = tangos.get_halo("sim/ts5/1").calculate_for_progenitors("halo_number()")
+    assert np.all(halo_num==[1,1,1,2,2])
+
+def test_major_progenitor_branch_from_merger_example():
+    import tangos.examples.mergers as mer
+    z_arr, ratio_arr, halo_arr = mer.get_mergers_of_major_progenitor(tangos.get_halo("sim/ts5/1"))
+    # the mergers example will see two major mergers happen - hard to avoid this without a lot of ad hoc rules
+    # Note also the major progenitor in the high-z collision is halo 2, not halo 1 (despite halo 1 being more massive).
+    # This is because most of the material in the remnant comes from halo 2.
+    testing.assert_halolists_equal(halo_arr, [("sim/ts4/1", "sim/ts4/2"), ("sim/ts2/2", "sim/ts2/1")])
+
+def test_tree_from_ts5():
+    t = tree.MergerTree(tangos.get_halo("sim/ts5/1"))
+    t.construct()
+    # should 'see' the final merger
+    assert t.summarise()=="1(1(1(2(2))),2(2(1(1))))"
+
+def test_tree_from_ts4():
+    t = tree.MergerTree(tangos.get_halo("sim/ts4/1"))
+    t.construct()
+    # should now 'see' the earlier partial merger, but not the 5% mass transfer
+    assert t.summarise()=="1(1(1(1),2(2)))"

--- a/tests/test_difficult_merger_scenario.py
+++ b/tests/test_difficult_merger_scenario.py
@@ -26,21 +26,21 @@ def setup():
 
     generator.add_timestep() # ts2
     generator.add_objects_to_timestep(2)
-    generator.link_last_halos(consistent_masses=True)
+    generator.link_last_halos(adjust_masses=True)
 
     generator.add_timestep() # ts3, in which halo 1 and 2 collide
     generator.add_objects_to_timestep(2)
-    generator.link_last_halos_using_mapping({1:2, 2:1}, consistent_masses=True) # halo 1 becomes 2, 2 becomes 1 due to mass ordering
+    generator.link_last_halos_using_mapping({1:2, 2:1}, adjust_masses=True) # halo 1 becomes 2, 2 becomes 1 due to mass ordering
     generator.add_mass_transfer(1,1,0.3, adjust_masses=True) # halo 1 in previous step loses 30% of its mass to halo 1 in this step... but survives
 
     generator.add_timestep() # ts4
     generator.add_objects_to_timestep(2)
-    generator.link_last_halos(consistent_masses=True)
+    generator.link_last_halos(adjust_masses=True)
     generator.add_mass_transfer(2,1,0.05, adjust_masses=True) # continued minor stripping of halo 2
 
     generator.add_timestep() #ts5, in which halo 1 and 2 finally merge completely
     generator.add_objects_to_timestep(1)
-    generator.link_last_halos_using_mapping({1:1, 2:1}, consistent_masses=True)
+    generator.link_last_halos_using_mapping({1:1, 2:1}, adjust_masses=True)
 
 def test_setup():
     ndm_test = [[x.NDM for x in tangos.get_timestep(ts).halos] for ts in range(1,6)]

--- a/tests/test_hop_strategy.py
+++ b/tests/test_hop_strategy.py
@@ -53,7 +53,7 @@ def setup():
                                              3: 3,
                                              4: 4,
                                              6: 5,
-                                             7: 5}, consistent_masses=False)
+                                             7: 5}, adjust_masses=False)
 
     generator.add_mass_transfer(1,1,0.1)
     generator.add_mass_transfer(4,3,0.01)
@@ -294,13 +294,13 @@ def test_major_progenitor_from_minor_progenitor():
     generator.add_objects_to_timestep(4)
     ts2 = generator.add_timestep()
     generator.add_objects_to_timestep(3)
-    generator.link_last_halos_using_mapping({1:2, 2:1, 3:3, 4:1}, consistent_masses=True)
+    generator.link_last_halos_using_mapping({1:2, 2:1, 3:3, 4:1}, adjust_masses=True)
     # ts1->ts2: most massive and second most massive halos swap rank ordering by mass because of the
     #           merger with ts1/h4.
     ts3 = generator.add_timestep()
     generator.add_objects_to_timestep(2)
     # ts2->ts3: there is a major merger of the most massive halos (ts2/h1+ts2/h2)->ts3/h1
-    generator.link_last_halos_using_mapping({1:1, 2:1, 3:2}, consistent_masses=True)
+    generator.link_last_halos_using_mapping({1:1, 2:1, 3:2}, adjust_masses=True)
 
     # Check major progenitor correctly reported one step back by MultiSourceMultiHopStrategy
     progen_in_ts2 = halo_finding.MultiSourceMultiHopStrategy(


### PR DESCRIPTION
`mergers.py` was not using the highest weight to define the major progenitor, as other parts of the code base do.