### PR TITLE
Display of 2D arrays as web server images

### DIFF
--- a/tangos/web/views/halo_data.py
+++ b/tangos/web/views/halo_data.py
@@ -251,7 +251,7 @@ def image_plot(request, val, property_info):
             data =val
 
         if width is not None:
-            if isinstance(width, tuple):
+            if hasattr(width, '__len__'):
                 p.imshow(data, extent=width)
             else:
                 p.imshow(data, extent=(-width/2, width/2, -width/2, width/2))

--- a/tangos/web/views/halo_data.py
+++ b/tangos/web/views/halo_data.py
@@ -250,9 +250,12 @@ def image_plot(request, val, property_info):
         else:
             data =val
 
-        if width is not None :
-            p.imshow(data,extent=(-width/2,width/2,-width/2,width/2))
-        else :
+        if width is not None:
+            if isinstance(width, tuple):
+                p.imshow(data, extent=width)
+            else:
+                p.imshow(data, extent=(-width/2, width/2, -width/2, width/2))
+        else:
             p.imshow(data)
 
         if property_info:


### PR DESCRIPTION
Hi,

Currently, the web server uses imshow to plot 2D arrays and can only handle x and y extents given as single number. It then generates an image centred on the central pixel of the 2D array with ranges (-X/2, X/2, -Y/2, Y/2). This breaks if storing two 2D arrays that are not symmetric around 0.

This little PR recognises if the property `plot_extent()`:
https://github.com/pynbody/tangos/blob/06c76503662f988e6f9adda9cb47f32f7f7e200e/tangos/properties/__init__.py#L174-L175
 has been defined as a tuple for imshow, while keeping the current behaviour if not. 

It uses isinstance (...) because I have no better idea on how to achieve this without significant refactoring of the plotting functions. Let me know what you think about it.

Martin
