### PR TITLE
Fix bug in property writer pre-requisite system

### DIFF
--- a/tangos/tools/property_writer.py
+++ b/tangos/tools/property_writer.py
@@ -221,6 +221,12 @@ class PropertyWriter(GenericTangosTool):
                 name = need_data[need_data_ids.index(x.name_id)]
                 existing_properties_data[name] = x.data
 
+        existing_links = db_halo.all_links
+        for x in existing_links:
+            if x.relation_id in need_data_ids:
+                name = need_data[need_data_ids.index(x.relation_id)]
+                existing_properties_data[name] = x.halo_to
+
         existing_properties_data.halo_number = db_halo.halo_number
         existing_properties_data.NDM = db_halo.NDM
         existing_properties_data.NGas = db_halo.NGas


### PR DESCRIPTION
Sometimes pre-requisites were being erroneously flagged as not present.

This occurred when the pre-requisite takes the form of a link, rather than a property.