### PR TITLE
make add_bh_fix more robust against crashing

### DIFF
--- a/tangos/scripts/add_bh.py
+++ b/tangos/scripts/add_bh.py
@@ -116,8 +116,10 @@ def scan_for_BHs(files, session):
         # re-order our information so that links refer to BHs in descending order of mass
         bh_order_by_mass = np.argsort(bh_mass_this_timestep)[::-1]
         bh_iord_this_timestep = bh_iord_this_timestep[bh_order_by_mass]
-        bh_halos = bh_halos[bh_order_by_mass]
-        bh_cen_halos = bh_cen_halos[bh_order_by_mass]
+        if bh_halos is not None:
+            bh_halos = bh_halos[bh_order_by_mass]
+        if bh_cen_halos is not None:
+            bh_cen_halos = bh_cen_halos[bh_order_by_mass]
 
         logger.info("Freeing the timestep particle data")
         with check_deleted(timestep_particle_data):


### PR DESCRIPTION
current code will crash due to lack of BHs in a timestep or potentially the choice of halo catalog (e.g. GrpCatalog) used in the input_handler. Avoid this simply by checking if bh_halos and bh_cen_halos is None before attempting to order those arrays.