### PR TITLE
Add ability to insist on using IDL-refined AHF catalogues 

### DIFF
--- a/tangos/input_handlers/__init__.py
+++ b/tangos/input_handlers/__init__.py
@@ -35,6 +35,8 @@ class HandlerBase(object):
     Subclasses provide implementations for different formats and situations.
     """
 
+    halo_stat_file_class_name = "HaloStatFile"
+
     def __init__(self, basename):
         self.basename = self.strip_slashes(basename)
         self.quicker = False # a flag to indicate that corners may be cut in the interest of efficiency
@@ -86,7 +88,7 @@ class HandlerBase(object):
         #ts = DummyTimeStep()
         #ts.redshift = self.get_timestep_properties(ts_extension)['redshift']
         from . import caterpillar
-        statfile = halo_stat_files.HaloStatFile(self._extension_to_filename(ts_extension))
+        statfile = getattr(halo_stat_files, self.halo_stat_file_class_name)(self._extension_to_filename(ts_extension))
         return statfile
 
 


### PR DESCRIPTION
Add ability to insist on using IDL-refined AHF catalogues (Alyson Brooks' toolset),
or to insist on ignoring those catalogues. This is in response to issue #117, where
it has become clear people have both types of catalogue on disk and this can cause
severe confusion due to the automated search for catalogues and statistics files.

To insist on using IDL-generated catalogues, use

```
tangos add <name_of_sim> --handler=pynbody.ChangaUseIDLInputHandler
```

To insist on ignoring IDL-generated catalogues, use

```
tangos add <name_of_sim> --handler=pynbody.ChangaIgnoreIDLInputHandler
```

The default behaviour remains unchanged (it will guess the best files to use,
which can lead to confusion if there is more than one type of catalogue
hanging around on disk)