### PR TITLE
Fix issue #121

### DIFF
--- a/tangos/tools/property_writer.py
+++ b/tangos/tools/property_writer.py
@@ -219,7 +219,7 @@ class PropertyWriter(GenericTangosTool):
         for x in existing_properties:
             if x.name_id in need_data_ids:
                 name = need_data[need_data_ids.index(x.name_id)]
-                existing_properties_data[name] = x.data
+                existing_properties_data[name] = x.data_raw
 
         existing_links = db_halo.all_links
         for x in existing_links:

--- a/tests/test_db_writer.py
+++ b/tests/test_db_writer.py
@@ -30,6 +30,19 @@ class DummyPropertyCausingException(properties.PropertyCalculation):
     def calculate(self, data, entry):
         raise RuntimeError("Test of exception handling")
 
+class DummyPropertyWithReconstruction(properties.PropertyCalculation):
+    names = "dummy_property_with_reconstruction",
+    requries_particle_data = False
+    callback = None
+
+    def calculate(self, data, entry):
+        return 1.0,
+
+    def reassemble(self, property_name):
+        if self.callback:
+            self.callback() # hook to allow us to know reassemble has been called
+        return 2.0
+
 def init_blank_simulation():
     testing.init_blank_db_for_testing(timeout=0.0)
     db.config.base = os.path.join(os.path.dirname(__file__), "test_simulations")
@@ -137,3 +150,16 @@ def test_link_dependency():
     run_writer_with_args("dummy_link")
     run_writer_with_args("dummy_property_requiring_link")
     assert db.get_default_session().query(db.core.HaloProperty).count() == 15
+
+def test_writer_sees_raw_properties():
+    # regression test for issue #121
+    init_blank_simulation()
+    run_writer_with_args("dummy_property_with_reconstruction")
+    assert db.get_halo(2)['dummy_property_with_reconstruction']==2.0
+    assert db.get_halo(2).calculate('raw(dummy_property_with_reconstruction)')==1.0
+
+    def raise_exception(obj):
+        raise RuntimeError("reconstruct has been called")
+
+    DummyPropertyWithReconstruction.callback = raise_exception
+    run_writer_with_args("dummy_property_with_reconstruction") # should not try to reconstruct the existing data stream


### PR DESCRIPTION
This is a performance issue where reconstructions of properties were made during
the writing process. We will now define the behaviour to be that raw properties are
always gathered, rather than allowing reconstruction to go ahead.

Specifically, Issue #121 was caused by tangos attempting to reconstruct SFR_histogram during the
process of checking whether it had already been written. This led to immense slow-down
and so many different merger tree searches that name collisions started happening in
the SQLAlchemy temporary table mappings.