### PR TITLE
Fix for python 3.8 on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ sudo: false
 
 # specify different versions of python and numpy
 env:
-  - PYTHON=2.7  NUMPY_VERSION=1.13.1
-  - PYTHON=3.5  NUMPY_VERSION=1.13.1
-  - PYTHON=3.6  NUMPY_VERSION=1.13.1
-  - PYTHON=3.7  NUMPY_VERSION=1.15.1
-  - PYTHON=3.8  NUMPY_VERSION=1.18.5
+  - PYTHON=2.7  NUMPY_VERSION=1.13.1  YT="yt=3.4.0"
+  - PYTHON=3.5  NUMPY_VERSION=1.13.1  YT="yt=3.4.0"
+  - PYTHON=3.6  NUMPY_VERSION=1.13.1  YT="yt>=3.4.0"
+  - PYTHON=3.7  NUMPY_VERSION=1.15.1  YT="yt>=3.4.0"
+  - PYTHON=3.8  NUMPY_VERSION=1.18.5  YT="yt>=3.4.0"
 
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -30,7 +30,7 @@ install:
   - cd pynbody
   - python setup.py install
   - cd ..
-  - pip install yt>=3.4.0
+  - pip install ${YT}
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: false
 # specify different versions of python and numpy
 env:
   - PYTHON=2.7  NUMPY_VERSION=1.13.1  YT="yt==3.4.0"
-  - PYTHON=3.5  NUMPY_VERSION=1.13.1  YT="yt==3.4.0"
+  - PYTHON=3.5  NUMPY_VERSION=1.13.1  YT="parso==0.7.0 yt==3.4.0"
   - PYTHON=3.6  NUMPY_VERSION=1.13.1  YT="yt>=3.4.0"
   - PYTHON=3.7  NUMPY_VERSION=1.15.1  YT="yt>=3.4.0"
   - PYTHON=3.8  NUMPY_VERSION=1.18.5  YT="yt>=3.4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - PYTHON=3.5  NUMPY_VERSION=1.13.1
   - PYTHON=3.6  NUMPY_VERSION=1.13.1
   - PYTHON=3.7  NUMPY_VERSION=1.15.1
+  - PYTHON=3.8  NUMPY_VERSION=1.18.5
 
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ sudo: false
 
 # specify different versions of python and numpy
 env:
-  - PYTHON=2.7  NUMPY_VERSION=1.13.1  YT="yt=3.4.0"
-  - PYTHON=3.5  NUMPY_VERSION=1.13.1  YT="yt=3.4.0"
+  - PYTHON=2.7  NUMPY_VERSION=1.13.1  YT="yt==3.4.0"
+  - PYTHON=3.5  NUMPY_VERSION=1.13.1  YT="yt==3.4.0"
   - PYTHON=3.6  NUMPY_VERSION=1.13.1  YT="yt>=3.4.0"
   - PYTHON=3.7  NUMPY_VERSION=1.15.1  YT="yt>=3.4.0"
   - PYTHON=3.8  NUMPY_VERSION=1.18.5  YT="yt>=3.4.0"

--- a/tangos/query.py
+++ b/tangos/query.py
@@ -84,11 +84,11 @@ get_halo = get_object # old naming convention - to be deprecated
 
 def get_item(path, session=None):
     c = path.count("/")
-    if c is 0:
+    if c == 0:
         return get_simulation(path, session)
-    elif c is 1:
+    elif c == 1:
         return get_timestep(path, session)
-    elif c is 2:
+    elif c == 2:
         return get_halo(path, session)
 
 


### PR DESCRIPTION
A change to the default start method in the multiprocessing module caused
multiple tests to fail, because parallel_tasks with the multiprocessing
backend was broken.

Additional fix to remove comparison of integers using 'is' (I believe this
used to be guaranteed to be fine in the reference implementation, but was
pointlessly risky anyway and now triggers a SyntaxWarning)