### PR TITLE
Address issues #123 and #124: earliest() and latest() live calculations

### DIFF
--- a/tangos/live_calculation/__init__.py
+++ b/tangos/live_calculation/__init__.py
@@ -432,7 +432,7 @@ class LiveProperty(Calculation):
         return results_array
 
     def proxy_value(self):
-        return UnknownValue()
+        return UnknownValue(self)
 
 class BuiltinFunction(LiveProperty):
     """Represents a calculation that is achieved by executing a python function. See the builtin_functions module."""
@@ -553,7 +553,7 @@ class Link(Calculation):
 
     def proxy_value(self):
         """Return a placeholder value for this calculation"""
-        return UnknownValue()
+        return UnknownValue(self)
 
     def retrieves(self):
         # the property retrieval will not be on the set of halos known to higher levels,

--- a/tangos/live_calculation/builtin_functions/__init__.py
+++ b/tangos/live_calculation/builtin_functions/__init__.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import tangos
 from tangos.util import consistent_collection
-from .. import BuiltinFunction, FixedInput, FixedNumericInput, StoredProperty
+from .. import BuiltinFunction, FixedInput, FixedNumericInput, StoredProperty, LiveProperty
 from ... import core
 from ...core import extraction_patterns
 
@@ -40,13 +40,14 @@ earlier.set_input_options(0, provide_proxy=True, assert_class = FixedNumericInpu
 
 @BuiltinFunction.register
 def latest(source_halos):
-    timestep = consistent_collection.ConsistentCollection(source_halos).timestep.get_final()
-    return match(source_halos, timestep)
+    from .search import find_descendant
+    return find_descendant(source_halos, LiveProperty('t').proxy_value(), 'max')
+
 
 @BuiltinFunction.register
 def earliest(source_halos):
-    timestep = consistent_collection.ConsistentCollection(source_halos).timestep.get_final(-1)
-    return match(source_halos, timestep)
+    from .search import find_progenitor
+    return find_progenitor(source_halos, LiveProperty('t').proxy_value(), 'min')
 
 @BuiltinFunction.register
 def has_property(source_halos, property):

--- a/tangos/live_calculation/builtin_functions/search.py
+++ b/tangos/live_calculation/builtin_functions/search.py
@@ -6,29 +6,29 @@ from ... import core
 from ... import relation_finding
 from ... import temporary_halolist as thl
 
-@BuiltinFunction.register
-def find_progenitor(source_halos, property_name, property_criterion):
-    if property_criterion!='min' and property_criterion!='max':
+def _find_progenitor_or_descendant(source_halos, property_proxy, property_criterion, strategy):
+    if property_criterion != 'min' and property_criterion != 'max':
         raise ValueError("Property criterion must be either 'min' or 'max'")
 
-    if len(source_halos)==0:
+    if len(source_halos) == 0:
         return []
 
-    all_major_progs = relation_finding.multi_source.MultiSourceAllMajorProgenitorsStrategy(source_halos)
+    all_major_progs = strategy(source_halos)
 
     sources = all_major_progs.sources()
 
-    property_and_obj = MultiCalculation(ReturnInputHalos(), property_name.name)
+    property_and_obj = MultiCalculation(ReturnInputHalos(), property_proxy.name)
 
-    with all_major_progs.temp_table() as tt :
+    with all_major_progs.temp_table() as tt:
         raw_query = thl.halo_query(tt)
         query = property_and_obj.supplement_halo_query(raw_query)
         all_major_progs = query.all()
-        db_objects, values = property_and_obj.values_sanitized(all_major_progs, core.Session.object_session(source_halos[0]))
+        db_objects, values = property_and_obj.values_sanitized(all_major_progs,
+                                                               core.Session.object_session(source_halos[0]))
 
     # now re-organize the values so that we have one per source
-    values_per_source = {s:[] for s in range(len(source_halos))}
-    objs_per_source = {s:[] for s in range(len(source_halos))}
+    values_per_source = {s: [] for s in range(len(source_halos))}
+    objs_per_source = {s: [] for s in range(len(source_halos))}
     for source, value, obj in zip(sources, values, db_objects):
         values_per_source[source].append(value)
         objs_per_source[source].append(obj)
@@ -37,19 +37,29 @@ def find_progenitor(source_halos, property_name, property_criterion):
     for s in range(len(source_halos)):
         vals = values_per_source[s]
         objs = objs_per_source[s]
-        assert len(vals)==len(objs)
-        if len(vals)==0:
+        assert len(vals) == len(objs)
+        if len(vals) == 0:
             results.append(None)
         else:
-            if property_criterion=='min':
+            if property_criterion == 'min':
                 index = np.argmin(vals)
-            elif property_criterion=='max':
+            elif property_criterion == 'max':
                 index = np.argmax(vals)
             else:
-                assert False # should not reach this point
+                assert False  # should not reach this point
             results.append(objs[index])
     return results
 
+@BuiltinFunction.register
+def find_progenitor(source_halos, property_proxy, property_criterion):
+   return _find_progenitor_or_descendant(source_halos, property_proxy, property_criterion,
+                                         relation_finding.multi_source.MultiSourceAllMajorProgenitorsStrategy)
+
+
+@BuiltinFunction.register
+def find_descendant(source_halos, property_proxy, property_criterion):
+   return _find_progenitor_or_descendant(source_halos, property_proxy, property_criterion,
+                                         relation_finding.multi_source.MultiSourceAllMajorDescendantsStrategy)
 
 
 find_progenitor.set_input_options(0, provide_proxy=True, assert_class = StoredProperty)

--- a/tangos/relation_finding/multi_source.py
+++ b/tangos/relation_finding/multi_source.py
@@ -177,3 +177,12 @@ class MultiSourceAllMajorProgenitorsStrategy(MultiSourceMultiHopStrategy):
 
     def _should_halt(self):
         return False
+
+class MultiSourceAllMajorDescendantsStrategy(MultiSourceMultiHopStrategy):
+
+    def __init__(self, halos_from, **kwargs):
+        super(MultiSourceAllMajorDescendantsStrategy, self).__init__(halos_from, None, one_match_per_input=False,
+                                                                     directed='forwards', include_startpoint=True)
+
+    def _should_halt(self):
+        return False


### PR DESCRIPTION
* latest() would give no result if called from the last snapshot.
* earliest() would give no result if the halo did not exist in the very first timestep.

The problems were quite deeply embedded in the algorithm, which looked for the corresponding halo in a particular
timestep instead of just following the tree as far as possible (as other parts of tangos would do).

To address this, both functions have been moved to a new algorithm based on the existing find_progenitor function.