### PR TITLE
Improve performance for tree searches, and fix related bugs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open(path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 setup(name='tangos',
-      version='1.1.0',
+      version='1.1.1',
       description='TANGOS, the agile numerical galaxy organisation system',
       classifiers=[
           "Development Status :: 5 - Production/Stable",

--- a/tangos/__init__.py
+++ b/tangos/__init__.py
@@ -22,4 +22,4 @@ from .core import *
 from .query import *
 from . import properties
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/tangos/live_calculation/builtin_functions/search.py
+++ b/tangos/live_calculation/builtin_functions/search.py
@@ -13,27 +13,33 @@ def _find_progenitor_or_descendant(source_halos, property_proxy, property_criter
     if len(source_halos) == 0:
         return []
 
-    all_major_progs = strategy(source_halos)
+    all_major_progs_strategy = strategy(source_halos)
 
-    sources = all_major_progs.sources()
+    sources_for_each_value = all_major_progs_strategy.sources()
 
     property_and_obj = MultiCalculation(ReturnInputHalos(), property_proxy.name)
 
-    with all_major_progs.temp_table() as tt:
+    with all_major_progs_strategy.temp_table() as tt:
         # the query has to explicitly include the source_id, otherwise the sqlalchemy dedup
         # process removes duplicates rows (e.g. if there are several null results, only the
         # first will be returned!)
         raw_query = thl.enumerated_halo_query(tt)
         query = property_and_obj.supplement_halo_query(raw_query)
         all_major_progs = [x[1] for x in query.all()]
-        db_objects, values = property_and_obj.values_sanitized(all_major_progs,
-                                                               core.Session.object_session(source_halos[0]))
+        db_objects_for_each_value, values = property_and_obj.values(all_major_progs)
 
-    assert len(values) == len(all_major_progs) == len(sources)
+    assert len(values) == len(all_major_progs) == len(sources_for_each_value)
+
+    # eliminate all None values
+    mask = np.asarray(values)!=None
+    sources_for_each_value = np.asarray(sources_for_each_value)[mask]
+    db_objects_for_each_value = np.asarray(db_objects_for_each_value)[mask]
+    values = np.asarray(values)[mask]
+
     # now re-organize the values so that we have one per source
     values_per_source = {s: [] for s in range(len(source_halos))}
     objs_per_source = {s: [] for s in range(len(source_halos))}
-    for source, value, obj in zip(sources, values, db_objects):
+    for source, value, obj in zip(sources_for_each_value, values, db_objects_for_each_value):
         values_per_source[source].append(value)
         objs_per_source[source].append(obj)
 
@@ -45,13 +51,17 @@ def _find_progenitor_or_descendant(source_halos, property_proxy, property_criter
         if len(vals) == 0:
             results.append(None)
         else:
-            if property_criterion == 'min':
-                index = np.argmin(vals)
-            elif property_criterion == 'max':
-                index = np.argmax(vals)
-            else:
-                assert False  # should not reach this point
-            results.append(objs[index])
+            try:
+                if property_criterion == 'min':
+                    index = np.argmin(vals)
+                elif property_criterion == 'max':
+                    index = np.argmax(vals)
+                else:
+                    assert False  # should not reach this point
+                results.append(objs[index])
+            except ValueError:
+                results.append(None) # argmin/argmax of empty sequence -> no candidate results
+
     return results
 
 @BuiltinFunction.register
@@ -68,3 +78,6 @@ def find_descendant(source_halos, property_proxy, property_criterion):
 
 find_progenitor.set_input_options(0, provide_proxy=True, assert_class = StoredProperty)
 find_progenitor.set_input_options(1, provide_proxy=True, assert_class = FixedInput)
+
+find_descendant.set_input_options(0, provide_proxy=True, assert_class = StoredProperty)
+find_descendant.set_input_options(1, provide_proxy=True, assert_class = FixedInput)

--- a/tangos/properties/intrinsic.py
+++ b/tangos/properties/intrinsic.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from . import LivePropertyCalculation
 
 class IntrinsicProperties(LivePropertyCalculation):
-    names = "t","z","a","dbid", "halo_number", "finder_id", "NDM", "NStar", "NGas", "type", "step_path"
+    names = "t","z","a","dbid", "halo_number", "finder_id", "NDM", "NStar", "NGas", "type", "step_path", "path"
 
     def live_calculate(self, halo):
         ts = halo.timestep
         return ts.time_gyr, ts.redshift, 1./(1.+ts.redshift), halo.id, halo.halo_number, halo.finder_id, \
-               halo.NDM, halo.NStar, halo.NGas, halo.object_typecode, str(halo.timestep.path)
+               halo.NDM, halo.NStar, halo.NGas, halo.object_typecode, str(halo.timestep.path), str(halo.path)

--- a/tangos/relation_finding/multi_hop.py
+++ b/tangos/relation_finding/multi_hop.py
@@ -92,6 +92,12 @@ class MultiHopStrategy(HopStrategy):
 
     def temp_table(self):
         """Execute the strategy and return results as a temp_table (see temporary_halolist module)"""
+        if self._all is None:
+            return self._temp_table_without_leaving_sql()
+        else:
+            return temporary_halolist.temporary_halolist_table(self.session, [x.halo_to_id for x in self._all])
+
+    def _temp_table_without_leaving_sql(self):
         tt = self._manage_temp_table()
         tt.__enter__()
         try:

--- a/tests/test_live_calculation_link_syntax.py
+++ b/tests/test_live_calculation_link_syntax.py
@@ -128,6 +128,13 @@ def test_historical_value_finding():
     timestep = db.get_timestep("sim/ts3")
     assert_halolists_equal(timestep.calculate_all("find_progenitor(testval, 'max')")[0], ["sim/ts2/1", "sim/ts3/2"])
     assert_halolists_equal(timestep.calculate_all("find_progenitor(testval, 'min')")[0], ["sim/ts3/1", "sim/ts1/3"])
+    assert_halolists_equal(db.get_timestep("sim/ts1").calculate_all("find_descendant(testval, 'min')")[0],
+                           ["sim/ts3/1", "sim/ts1/3", "sim/ts1/4", "sim/ts1/5"])
+
+def test_historical_value_finding_missing_data():
+    sources, targets = db.get_timestep("sim/ts3").calculate_all("path()", "find_progenitor(testvalpartial, 'max')")
+    assert_halolists_equal(sources, ["sim/ts3/1", "sim/ts3/2"])
+    assert_halolists_equal(targets, ["sim/ts1/2", "sim/ts1/3"])
 
 def test_latest_earliest():
     earliest = db.get_halo("sim/ts3/1").calculate("earliest()")


### PR DESCRIPTION
Significant performance enhancements to `earliest`, `latest` etc in response to re-opened issue #127 

Also fixes bug which showed when data was missing for a search with `find_progenitor`