### PR TITLE
Fixed escaping of '/'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ sudo: false
 
 # specify different versions of python and numpy
 env:
-  - PYTHON=3.6  NUMPY_VERSION=1.13.1  YT="yt>=3.4.0"
-  - PYTHON=3.7  NUMPY_VERSION=1.15.1  YT="yt>=3.4.0"
+  - PYTHON=3.6  NUMPY_VERSION=1.18.5  YT="yt>=3.4.0"
+  - PYTHON=3.7  NUMPY_VERSION=1.18.5 YT="yt>=3.4.0"
   - PYTHON=3.8  NUMPY_VERSION=1.18.5  YT="yt>=3.4.0"
 
 before_install:

--- a/tangos/core/simulation.py
+++ b/tangos/core/simulation.py
@@ -90,7 +90,7 @@ class Simulation(Base):
 
     @property
     def escaped_basename(self):
-        return self.basename.replace("/","%")
+        return self.basename.replace("/","_")
 
 
 class SimulationProperty(Base):

--- a/tangos/query.py
+++ b/tangos/query.py
@@ -22,8 +22,8 @@ def get_simulation(id, session=None):
     if session is None:
         session = get_default_session()
     if isinstance(id, str) or isinstance(id, six.text_type):
-        assert "/" not in id
-        if "%" in id:
+        assert "/" not in id, "Replace '/' with '_' in input string."
+        if "%" in id or "_" in id:
             match_clause = Simulation.basename.like(id)
         else:
             match_clause = Simulation.basename == id

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -142,6 +142,6 @@ def test_simulation_with_slash():
     assert "halo 1 of ts1" in halo_response
     calculate_url = halo_response.pyquery("#calculate_url").text()
     calculate_url = parse.unquote(calculate_url)
-    assert "simname%has%slashes" in calculate_url
+    assert "simname_has_slashes" in calculate_url
     halo_next_step_response = halo_response.click("\+1$").follow()
     assert "halo 1 of ts2" in halo_next_step_response


### PR DESCRIPTION
Escaping the '/' character in simulation names with a '%' wildcard causes issues with certain names. For example, the parser cannot tell the difference between "sim/model_variation" and "sim2/model_variation". The web interface will return a "404 Not Found" error for the former string (and the python module will also fail), because both of these strings match "sim%model_variation".

I've made two small changes to the code which escape '/' with an underscore, rather than with '%'. This is a wildcard for a single character, rather than for any number of characters, and resolves the above issue. I also added a warning message in the assertion for when '/' appears in simulation names.