### PR TITLE
Allowing calculation of center for each pynbody family

### DIFF
--- a/tangos/properties/pynbody/centring.py
+++ b/tangos/properties/pynbody/centring.py
@@ -4,18 +4,23 @@ import numpy as np
 import functools
 import contextlib
 
+
 class CentreAndRadius(PynbodyPropertyCalculation):
     names = "shrink_center", "max_radius"
 
     def calculate(self, halo, existing_properties):
+        dm_center, dm_max_radius = self._get_centre_and_max_radius(halo.dm)
+        return dm_center, dm_max_radius
+
+    def _get_centre_and_max_radius(self, particle_data):
         # this does not appear at module level because we want tangos to be importable even when pynbody is not
         # present:
         import pynbody
 
         # ensure the box is wrapped correctly by centring on one of the particles:
-        temporary_centre = np.array(halo['pos'][0])
-        with _recenter(halo, temporary_centre):
-            center = pynbody.analysis.halo.shrink_sphere_center(halo.dm, shrink_factor=0.8, velocity=False)
+        temporary_centre = np.array(particle_data['pos'][0])
+        with _recenter(particle_data, temporary_centre):
+            center = pynbody.analysis.halo.shrink_sphere_center(particle_data, shrink_factor=0.8, velocity=False)
 
             # mark_timer can be used to track timing of parts of the calculation. The results of these timings
             # appears in the tangos_writer logs:
@@ -25,14 +30,30 @@ class CentreAndRadius(PynbodyPropertyCalculation):
                 raise RuntimeError("Something bizarre has happened with the centering")
 
             # measure rmax from the robust centre we have now identified:
-            halo['pos'] -= center
+            particle_data['pos'] -= center
 
-            center+=temporary_centre  # centre should be relative to original snapshot!
+            center += temporary_centre  # centre should be relative to original snapshot!
 
-            rmax = pynbody.derived.r(halo).max()
+            rmax = pynbody.derived.r(particle_data).max()
             # N.B. not using halo['r'] which could end up calculating r across entire simulation, needlessly
 
         return center.view(np.ndarray), rmax
+
+
+class CentreAndRadiusStars(CentreAndRadius):
+    names = "stars_shrink_center", "stars_max_radius"
+
+    def calculate(self, halo, existing_properties):
+        stars_center, stars_max_radius = self._get_centre_and_max_radius(halo.st)
+        return stars_center, stars_max_radius
+
+
+class CentreAndRadiusGas(CentreAndRadius):
+    names = "gas_shrink_center", "gas_max_radius"
+
+    def calculate(self, halo, existing_properties):
+        gas_center, gas_max_radius = self._get_centre_and_max_radius(halo.g)
+        return gas_center, gas_max_radius
 
 
 class CentreAndRadiusComoving(LivePropertyCalculation):
@@ -46,14 +67,13 @@ class CentreAndRadiusComoving(LivePropertyCalculation):
         return halo['shrink_center']/scalefactor, halo['max_radius']/scalefactor
 
 
-
 @contextlib.contextmanager
 def _recenter(halo, centre):
     original_positions = np.array(halo['pos'])  # take a copy so we can put everything back at the end
-    halo['pos']-=centre
+    halo['pos'] -= centre
     halo.wrap()
     yield
-    halo['pos']=original_positions
+    halo['pos'] = original_positions
 
 
 def centred_calculation(fn):


### PR DESCRIPTION
Hi all, 

The following PR is a quick refactoring of the centering property to allow calculations on stars and gas independently of the traditional DM shrink center. I tried to mimic the naming conventions in other stellar and gaseous properties, and decided against changing the name of existing center for backward compatibility. Any comments welcome!

Martin