### PR TITLE
Address issue #135. Add unit test.

### DIFF
--- a/tangos/util/timing_monitor.py
+++ b/tangos/util/timing_monitor.py
@@ -52,10 +52,20 @@ class TimingMonitor(object):
         self._unset_as_monitor_for(self._monitoring)
         self._time_marks_info.append("end")
         self._time_marks.append(time.time())
-        previous_timings = self.timings_by_class.get(cl, 0)
-        cumulative_timings = np.diff(self._time_marks)+previous_timings
-        self.timings_by_class[cl] = cumulative_timings
-        self.labels_by_class[cl] = self._time_marks_info
+        previous_timings = self.timings_by_class.get(cl, None)
+        if previous_timings is None or len(previous_timings) == len(self._time_marks)-1:
+            cumulative_timings = np.diff(self._time_marks)
+            if previous_timings is not None:
+                cumulative_timings+=previous_timings
+            self.timings_by_class[cl] = cumulative_timings
+            self.labels_by_class[cl] = self._time_marks_info
+        else:
+            # Incompatibility between this and previous timings from the same procedure. Can only track total time spent.
+            start_time = self._time_marks[0]
+            end_time = self._time_marks[-1]
+            time_elapsed = end_time-start_time + sum(previous_timings)
+            self.labels_by_class[cl] = ['start','end']
+            self.timings_by_class[cl] = [time_elapsed]
 
 
     def mark(self, label=None):

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,40 @@
+import tangos.util.timing_monitor as tm
+import logging
+from tangos.log import LogCapturer, logger
+
+class Dummy():
+    pass
+
+def test_timing_graceful_fail():
+    x=Dummy()
+    x.timing_monitor=None
+    TM = tm.TimingMonitor()
+
+
+    lc = LogCapturer()
+
+    for i in range(5):
+        with TM(x):
+            TM.mark("hello")
+            TM.mark("goodbye")
+
+    with lc:
+        TM.summarise_timing(logger)
+
+    assert "INTERNAL BREAKDOWN" in lc.get_output()
+    assert "hello" in lc.get_output()
+    assert "goodbye" in lc.get_output()
+
+    # Now intentionally break the time measurements by failing to mark 'hello' and 'goodbye'
+    with TM(x):
+        pass
+
+    lc = LogCapturer()
+
+    with lc:
+        TM.summarise_timing(logger)
+
+    assert "hello" not in lc.get_output()
+    assert "goodbye" not in lc.get_output()
+    assert "INTERNAL BREAKDOWN" not in lc.get_output()
+    assert "Dummy" in lc.get_output()


### PR DESCRIPTION
Addresses an issue where the time monitor would crash when it was monitoring
a procedure that ran inconsistently between different invocations, e.g. because
the underlying procedure terminated early.