### PR TITLE
update to BH data reader

### DIFF
--- a/tangos/input_handlers/changa_bh.py
+++ b/tangos/input_handlers/changa_bh.py
@@ -158,7 +158,7 @@ class BlackHolesLog(BHLogData):
 
         unique_step, unique_ind, unique_step_inv = np.unique(step[osort], return_inverse=True, return_index=True)
         dt_ustep = time[osort[unique_ind[1:]]] - time[osort[unique_ind[:-1]]]
-        dt_ustep = np.insert(0, dt_ustep[0])
+        dt_ustep = np.insert(dt_ustep, 0, dt_ustep[0])
         dt_out[osort] = dt_ustep[unique_step_inv]
 
         mdotmean = dMaccum/dt_out

--- a/tangos/input_handlers/changa_bh.py
+++ b/tangos/input_handlers/changa_bh.py
@@ -14,14 +14,14 @@ class BHLogData(object):
     _n_cols = 0
 
     @classmethod
-    def can_load(cls, timestep_filename):
+    def can_load(cls, simname):
         try:
-            return os.path.exists(cls.filename(timestep_filename))
+            return os.path.exists(cls.filename(simname))
         except (ValueError, TypeError):
             return False
 
     @classmethod
-    def filename(cls, timestep_filename):
+    def filename(cls, simname):
         raise ValueError("Unknown path to stat file")
 
     @classmethod
@@ -49,7 +49,7 @@ class BHLogData(object):
         f = pynbody.load(filename)
         self.boxsize = float(f.properties['boxsize'].in_units('kpc', a=f.properties['a']))
         name, stepnum = re.match("^(.*)\.(0[0-9]*)$", filename).groups()
-        wrapped_ars = self.read_data(self.filename(filename), f)
+        wrapped_ars = self.read_data(self.filename(name), f)
         iord, time, step, mass, x, y, z, vx, vy, vz, mdot, mdotmean, dMaccum, scalefac = wrapped_ars
 
         logger.info("Loaded a BH log with %d entries", len(time))
@@ -137,8 +137,8 @@ class BlackHolesLog(BHLogData):
                      float, float, float, float, float, float]
 
     @classmethod
-    def filename(cls, timestep_filename):
-        return timestep_filename + '.BlackHoles'
+    def filename(cls, simname):
+        return simname + '.BlackHoles'
 
     def read_data(self, filename, sim):
         ars = [[] for i in range(self._n_cols)]

--- a/tangos/properties/pynbody/BH.py
+++ b/tangos/properties/pynbody/BH.py
@@ -10,7 +10,7 @@ import scipy, scipy.interpolate
 
 class BH(PynbodyPropertyCalculation):
 
-    names = "BH_mdot", "BH_mdot_ave", "BH_mdot_std", "BH_central_offset", "BH_central_distance", "BH_mass"
+    names = "BH_mdot", "BH_mdot_ave", "BH_central_offset", "BH_central_distance", "BH_mass"
     requires_particle_data = True
 
 
@@ -78,7 +78,7 @@ class BH(PynbodyPropertyCalculation):
             bad, = np.where(np.abs(offset) > boxsize / 2.)
             offset[bad] = -1.0 * (offset[bad] / np.abs(offset[bad])) * np.abs(boxsize - np.abs(offset[bad]))
 
-        return final['mdot'], final['mdotmean'], final['mdotsig'], offset, np.linalg.norm(offset), final['mass']
+        return final['mdot'], final['mdotmean'], offset, np.linalg.norm(offset), final['mass']
 
 
 class BHAccHistogram(TimeChunkedProperty):
@@ -93,7 +93,10 @@ class BHAccHistogram(TimeChunkedProperty):
         return []
 
     def preloop(self, f, db_timestep):
-        self.log = BHShortenedLog.get_existing_or_new(db_timestep.filename)
+        if BlackHolesLog.can_load(db_timestep.filename):
+            self.log = BlackHolesLog.get_existing_or_new(db_timestep.filename)
+        elif ShortenedOrbitLog.can_load(db_timestep.filename):
+            self.log = ShortenedOrbitLog.get_existing_or_new(db_timestep.filename)
 
     @classmethod
     def no_proxies(self):

--- a/tangos/properties/pynbody/BH.py
+++ b/tangos/properties/pynbody/BH.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import tangos.core.halo
-from tangos.input_handlers.changa_bh import BHShortenedLog
+from tangos.input_handlers.changa_bh import ShortenedOrbitLog, BlackHolesLog
 from . import PynbodyPropertyCalculation
 from .. import LivePropertyCalculation, TimeChunkedProperty
 import numpy as np
@@ -22,7 +22,12 @@ class BH(PynbodyPropertyCalculation):
         return True
 
     def preloop(self, f, db_timestep):
-        self.log = BHShortenedLog.get_existing_or_new(db_timestep.filename)
+        if BlackHolesLog.can_load(db_timestep.filename):
+            self.log = BlackHolesLog.get_existing_or_new(db_timestep.filename)
+        elif ShortenedOrbitLog.can_load(db_timestep.filename):
+            self.log = ShortenedOrbitLog.get_existing_or_new(db_timestep.filename)
+        else:
+            raise RuntimeError("cannot find recognizable log file")
         self.filename = db_timestep.filename
         print(self.log)
 
@@ -33,7 +38,7 @@ class BH(PynbodyPropertyCalculation):
 
         vars = self.log.get_for_named_snapshot(self.filename)
 
-        mask = vars['bhid'] == properties.halo_number
+        mask = vars['iord'] == properties.halo_number
         if (mask.sum() == 0):
             raise RuntimeError("Can't find BH in .orbit file")
 

--- a/tangos/properties/pynbody/BH.py
+++ b/tangos/properties/pynbody/BH.py
@@ -38,7 +38,7 @@ class BH(PynbodyPropertyCalculation):
 
         vars = self.log.get_for_named_snapshot(self.filename)
 
-        mask = vars['iord'] == properties.halo_number
+        mask = vars['bhid'] == properties.halo_number
         if (mask.sum() == 0):
             raise RuntimeError("Can't find BH in .orbit file")
 


### PR DESCRIPTION
The newest versions of changa have an updated BH output structure.  In order to promote backwards compatibility with older bh log file structures,  the single glass has now been split into a base class and two subclasses. The preloop step for BH properties now tests which of the two classes it should use. The class names have been updated in changa_bh.py to reflect these changes. the mdot_sigma is no longer included in the new output and so is also no longer be included in the BH property calculation. In theory, it would be easy to implement a new property reader for any formatted output file, or with any output handler, though right now I leave this to future work. 