### PR TITLE
Consider `None` values as False

### DIFF
--- a/tangos/core/timestep.py
+++ b/tangos/core/timestep.py
@@ -125,6 +125,8 @@ class TimeStep(Base):
                          any of the specified properties/live-calculations. Otherwise, return
                          None where no result could be obtained, guaranteeing the return of a row for
                          every object.
+
+        :param order_by_halo_number: if True, order by halo number; otherwise by database ID (default)
         """
 
         from .. import live_calculation
@@ -135,6 +137,8 @@ class TimeStep(Base):
         object_typetag = kwargs.get('object_type', kwargs.get('object_typetag',None))
         limit = kwargs.get('limit', None)
         sanitize = kwargs.get('sanitize', True)
+        order_by_halo_number = kwargs.get('order_by_halo_number', False)
+
         if object_typetag:
             object_typecode = Halo.object_typecode_from_tag(object_typetag)
 
@@ -148,6 +152,8 @@ class TimeStep(Base):
         session = Session()
         try:
             raw_query = session.query(Halo).filter_by(timestep_id=self.id)
+            if order_by_halo_number:
+                raw_query = raw_query.order_by(Halo.id)
             if object_typecode is not None:
                 raw_query = raw_query.filter_by(object_typecode=object_typecode)
             if limit:

--- a/tangos/core/timestep.py
+++ b/tangos/core/timestep.py
@@ -153,7 +153,7 @@ class TimeStep(Base):
         try:
             raw_query = session.query(Halo).filter_by(timestep_id=self.id)
             if order_by_halo_number:
-                raw_query = raw_query.order_by(Halo.id)
+                raw_query = raw_query.order_by(Halo.halo_number)
             if object_typecode is not None:
                 raw_query = raw_query.filter_by(object_typecode=object_typecode)
             if limit:

--- a/tangos/web/templates/timestep_view.jinja2
+++ b/tangos/web/templates/timestep_view.jinja2
@@ -209,7 +209,7 @@ function updateTableDisplay(object_tag) {
     for(var i=0; i<nData; i++) {
         var shouldDisplay = true;
         $.each(dataToFilterOn, function(j,c) {
-            if(c[i] === 'False') shouldDisplay = false;
+            if(c[i] !== 'True') shouldDisplay = false;
         });
         if(shouldDisplay) {
             if (nRowsTotal<endRow && nRowsTotal>=startRow) {

--- a/tangos/web/views/halo_data.py
+++ b/tangos/web/views/halo_data.py
@@ -108,7 +108,8 @@ def calculate_all(request):
     ts = timestep_from_request(request)
 
     try:
-        data, = ts.calculate_all(decode_property_name(request.matchdict['nameid']), sanitize=False)
+        data, = ts.calculate_all(decode_property_name(request.matchdict['nameid']),
+                                 sanitize=False, order_by_halo_number=True)
     except Exception as e:
         return {'error': getattr(e,'message',""), 'error_class': type(e).__name__}
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -27,6 +27,17 @@ def setup():
 
     tangos.get_default_session().commit()
 
+    creator.add_timestep()  # add ts 4
+    creator.add_objects_to_timestep(3)
+    tangos.get_default_session().commit()
+    # now make the object have halo numbers which have a different ordering to the database IDs
+    tangos.get_item("sim/ts4/1")['test_value'] = 1.0
+    tangos.get_item("sim/ts4/2")['test_value'] = 2.0
+    tangos.get_item("sim/ts4/3")['test_value'] = 3.0
+    tangos.get_item("sim/ts4/1").halo_number = 10
+    tangos.get_default_session().commit()
+
+
     creator = tangos.testing.simulation_generator.TestSimulationGenerator("simname/has/slashes")
     creator.add_timestep()
     creator.add_objects_to_timestep(1)
@@ -36,7 +47,7 @@ def setup():
     tangos.get_simulation(2).timesteps[0].halos[0]['test_value'] = 2.0
     tangos.get_default_session().commit()
 
-    
+
 
     global app
     app = TestApp(tangos.web.main({}))
@@ -147,3 +158,17 @@ def test_simulation_with_slash():
     assert "simname_has_slashes" in calculate_url
     halo_next_step_response = halo_response.click("\+1$").follow()
     assert "halo 1 of ts2" in halo_next_step_response
+
+
+def test_ordering_as_expected():
+    """Tests for an issue where data returned to the web interface was in a different order to the initial table,
+    causing results to be displayed out of order"""
+    assert (tangos.get_item("sim/ts4").calculate_all("halo_number()") == np.array([10,2,3])).all()
+    assert (tangos.get_item("sim/ts4").calculate_all("halo_number()",order_by_halo_number=True) == np.array([2,3,10])).all()
+
+    response = app.get("/sim/ts4/gather/test_value.json")
+    assert response.content_type == 'application/json'
+    assert response.status_int == 200
+    result = json.loads(response.body.decode('utf-8'))
+    assert result['timestep'] == 'ts4'
+    assert result['data_formatted'] == ["2.00", "3.00", "1.00"]


### PR DESCRIPTION
This allows filters to only keep elements being equal to `True`, thus rejecting e.g. `None`.

Based on #142, so should be merged after.

