### PR TITLE
Update web interface to use filters in halo view

### DIFF
--- a/tangos/config.py
+++ b/tangos/config.py
@@ -65,6 +65,9 @@ DEFAULT_SLEEP_BEFORE_ALLOWING_NEXT_LOCK = 1.0
 # Default format to use in the webview. Can be either svg or png
 webview_default_image_format = 'svg'
 
+# Caching time in seconds for image and data in the web server
+webview_cache_time = 3600
+
 try:
     from .config_local import *
 except:

--- a/tangos/properties/pynbody/profile.py
+++ b/tangos/properties/pynbody/profile.py
@@ -7,11 +7,15 @@ class HaloDensityProfile(SphericalRegionPropertyCalculation):
 
     names = "dm_density_profile", "dm_mass_profile"
 
+    def __init__(self, simulation):
+        super().__init__(simulation)
+        self._xdelta = self._simulation.get("approx_resolution_kpc", 0.1)
+
     def plot_x0(self):
         return self.plot_xdelta()/2
 
     def plot_xdelta(self):
-        return self._simulation.get("approx_resolution_kpc", 0.1)
+        return self._xdelta
 
     def plot_xlabel(self):
         return "r/kpc"

--- a/tangos/web/routes.py
+++ b/tangos/web/routes.py
@@ -18,7 +18,7 @@ def includeme(config):
     config.add_route('halo_later', '/{simid}/{timestepid}/{halonumber}/later/{n}')
     config.add_route('halo_earlier', '/{simid}/{timestepid}/{halonumber}/earlier/{n}')
     config.add_route('halo_in', '/{simid}/{timestepid}/{halonumber}/in/{n}')
-    config.add_route('calculate_all', '/{simid}/{timestepid}/gather/{nameid}.json')
+    config.add_route('calculate_all', '/{simid}/{timestepid}/gather/{typetag}/{nameid}.json')
     config.add_route('get_property', '/{simid}/{timestepid}/{halonumber}/{nameid}.json')
     config.add_route('gathered_csv', '/{simid}/{timestepid}/{nameid1}/vs/{nameid2}.csv')
     config.add_route('gathered_plot', '/{simid}/{timestepid}/{nameid1}/vs/{nameid2}.{ext}')

--- a/tangos/web/static/dynamictable.js
+++ b/tangos/web/static/dynamictable.js
@@ -144,6 +144,12 @@ function uriEncodeQuery(name) {
     return name;
 }
 
+function uriDecodeQuery(name) {
+    name = name.replace(/_slash_/g,"/")
+    name = decodeURIComponent(name);
+    return name;
+}
+
 function getAllEditables() {
     var editables = [];
     forEach(allEditables, function(row) {

--- a/tangos/web/static/halo_view.js
+++ b/tangos/web/static/halo_view.js
@@ -218,7 +218,12 @@ function fetchPlot (isUpdate) {
   if (existingImgSrc === uri) { return }
 
   loadImage(uri, extension)
-  if (isUpdate === undefined || isUpdate === false) { $('#imgbox').empty().html("<div class='progress-spinner'></div>&nbsp;Generating plot...") } else { $('#imgbox').append("<div class='progress-spinner'></div>&nbsp;Updating...") }
+  if (isUpdate === undefined || isUpdate === false) {
+    $('#imgbox').empty().html("<div class='progress-spinner'></div>&nbsp;Generating plot...")
+  } else {
+    if($('#imgbox .progress-spinner').length===0)
+      $('#imgbox').append("<div class='progress-spinner'></div>&nbsp;Updating...")
+  }
   return true
 }
 

--- a/tangos/web/static/halo_view.js
+++ b/tangos/web/static/halo_view.js
@@ -21,7 +21,7 @@ function renderNavToAnother(previous, next) {
 
 function autoUpdateNavToAnother() {
   // Work out what the previous and next halos are, using the selected filters if possible
-  $("#nav-to-another").html("<img src='/static/spinner.gif'>");
+  $("#nav-to-another").html("<div class='progress-spinner'></div>");
   let object_tag = $("#object_typetag").text()
   let filter = getFilterArray(object_tag,'td', autoUpdateNavToAnother);
   if(filter === undefined) {
@@ -55,7 +55,7 @@ function autoUpdateNavToAnother() {
 
 function updateRowData (miniLanguageQuery, rowId) {
   plotFetchingDisabled = true
-  $('#nametg-' + rowId).html("<img src='/static/spinner.gif'/>" + miniLanguageQuery)
+  $('#nametg-' + rowId).html("<div class='progress-spinner'></div>" + miniLanguageQuery)
 
   // Plot controls need to be in DOM immediately, then rejigged later if they are not appropriate.
   // This is so that the correct radio buttons get ticked after a page update (otherwise the
@@ -152,7 +152,7 @@ var plotFetchingDisabled = false
 var existingImgSrc
 
 function fetchTree (isUpdate) {
-  if (!isUpdate) { $('#imgbox').empty().html("<img src='/static/spinner.gif' />&nbsp;Generating tree...") } else { $('#imgbox').append("<img src='/static/spinner.gif' />&nbsp;Updating tree...") }
+  if (!isUpdate) { $('#imgbox').empty().html("<div class='progress-spinner'></div>&nbsp;Generating tree...") } else { $('#imgbox').append("<div class='progress-spinner'></div>&nbsp;Updating tree...") }
   var url = $('#tree_url').text()
 
   $.ajax({
@@ -213,7 +213,7 @@ function fetchPlot (isUpdate) {
   if (existingImgSrc === uri) { return }
 
   loadImage(uri, extension)
-  if (isUpdate === undefined || isUpdate === false) { $('#imgbox').empty().html("<img src='/static/spinner.gif' />&nbsp;Generating plot...") } else { $('#imgbox').append("<img src='/static/spinner.gif' />&nbsp;Updating...") }
+  if (isUpdate === undefined || isUpdate === false) { $('#imgbox').empty().html("<div class='progress-spinner'></div>&nbsp;Generating plot...") } else { $('#imgbox').append("<div class='progress-spinner'></div>&nbsp;Updating...") }
   return true
 }
 

--- a/tangos/web/static/halo_view.js
+++ b/tangos/web/static/halo_view.js
@@ -11,7 +11,7 @@ $.fn.markAsRowInsertPoint = function () {
 function renderNavToAnother(previous, next) {
    var el = $("#nav-to-another");
    el.text("");
-   var link = $("#timestep_url").text()+$("#object_typetag").text()
+   var link = $("#timestep_url").text()+"/"+$("#object_typetag").text()
    if(previous!==undefined && previous>0)
        el.append(`<a href="${link}_${previous}" class="ajaxenabled">${previous}</a> | `);
    el.append($('#halo_number').text());
@@ -49,6 +49,7 @@ function autoUpdateNavToAnother() {
     }
   }
   renderNavToAnother(previous, next);
+  ajaxEnableLinks("#nav-to-another");
 }
 
 
@@ -277,19 +278,21 @@ $(function () {
   function restoreInteractiveElements(isUpdate=true) {
     allEditables = [];
     $('#nametg-custom-row-1').markAsRowInsertPoint();
+    console.log($("#timestep_url").text());
+    setupTimestepTables($("#timestep_url").text());
     restoreAllEditables();
     restoreFormStates();
     fetchPlot(isUpdate);
     updatePositionsAfterScroll();
     var haloNum = parseInt($('#halo_number').text());
-    autoUpdateNavToAnother();
     ajaxEnableLinks();
+    autoUpdateNavToAnother();
   }
 
   // make sure interactivity is restored after ajax update
   postPageUpdate(restoreInteractiveElements);
 
   // put in interactivity for first time
-  setupTimestepTables($("#gather_url").text())
+  setupTimestepTables($("#timestep_url").text())
   restoreInteractiveElements(false);
 })

--- a/tangos/web/static/halo_view.js
+++ b/tangos/web/static/halo_view.js
@@ -98,7 +98,8 @@ function addBlankRow (after) {
 }
 
 function removeRow (name) {
-  $('#' + name).remove()
+  $('#' + name).remove();
+  autoUpdateNavToAnother();
 }
 
 function findInOtherSimulation () {

--- a/tangos/web/static/halo_view.js
+++ b/tangos/web/static/halo_view.js
@@ -163,8 +163,6 @@ function fetchTree (isUpdate) {
   var url = $('#tree_url').text()
 
   $.ajax({
-    type: 'POST',
-    data: { evaluate: JSON.stringify(getAllEditables()) },
     url: url,
     success: function (data) {
       $('#imgbox').empty()

--- a/tangos/web/static/halo_view.js
+++ b/tangos/web/static/halo_view.js
@@ -21,7 +21,8 @@ function renderNavToAnother(previous, next) {
 
 function autoUpdateNavToAnother() {
   // Work out what the previous and next halos are, using the selected filters if possible
-  $("#nav-to-another").html("<div class='progress-spinner'></div>");
+  if($("#nav-to-another .progress-spinner").length===0)
+    $("#nav-to-another").html("<div class='progress-spinner'></div>");
   let object_tag = $("#object_typetag").text()
   let filter = getFilterArray(object_tag,'td', autoUpdateNavToAnother);
   if(filter === undefined) {
@@ -153,7 +154,12 @@ var plotFetchingDisabled = false
 var existingImgSrc
 
 function fetchTree (isUpdate) {
-  if (!isUpdate) { $('#imgbox').empty().html("<div class='progress-spinner'></div>&nbsp;Generating tree...") } else { $('#imgbox').append("<div class='progress-spinner'></div>&nbsp;Updating tree...") }
+  if (!isUpdate) {
+    $('#imgbox').empty().html("<h3><div class='progress-spinner'></div>&nbsp;Generating tree...</h3>");
+  } else {
+    if($('#imgbox_container .progress-spinner').length === 0)
+      $('#imgbox').append("<h3><div class='progress-spinner'></div>&nbsp;Updating tree...</h3>");
+  }
   var url = $('#tree_url').text()
 
   $.ajax({

--- a/tangos/web/static/keeponscreen.js
+++ b/tangos/web/static/keeponscreen.js
@@ -3,7 +3,6 @@
 var scrollTop = {};
 
 function initScrollOffsetData() {
-    console.info("initScrollOffsetData");
     $(".keeponscreen").each(function() {
         if($(this).css('position')!='absolute') {
             // generate clone that keeps the space for this element

--- a/tangos/web/static/pageupdate.js
+++ b/tangos/web/static/pageupdate.js
@@ -60,8 +60,9 @@ function ajaxNavigate(rel, isPoppingFromHistory) {
     return false;
 }
 
-function ajaxEnableLinks() {
-    $('a.ajaxenabled').click(function() {
+function ajaxEnableLinks(inElement="") {
+    if (inElement.length>0) inElement=inElement+" "
+    $(inElement+'a.ajaxenabled').click(function() {
         ajaxNavigate(this.href);
         return false;
     })

--- a/tangos/web/static/stylesheet.css
+++ b/tangos/web/static/stylesheet.css
@@ -41,6 +41,25 @@ table#objects-container tr td {
     vertical-align: top;
 }
 
+@keyframes rotation {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(359deg);
+  }
+}
+
+div.progress-spinner {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    background-image: url('/static/tangos-50x50.png');
+    background-size: cover;
+    background-repeat: no-repeat;
+    animation: rotation 2s infinite;
+    animation-timing-function: linear;
+}
 tr.tangos-data:nth-child(odd) {
     background-color: #eeeef3;
 }

--- a/tangos/web/static/timestepdata.js
+++ b/tangos/web/static/timestepdata.js
@@ -1,28 +1,13 @@
 
 
 function setupTimestepTables(gather_url) {
-    function persistTableData() {
-        sessionStorage['timestep-data-'+gather_url] =JSON.stringify(window.dataTables);
-    }
-
-    function restoreTableData() {
-        if(sessionStorage['timestep-data-'+gather_url] !== undefined)
-        {
-            try {
-                window.dataTables = JSON.parse(sessionStorage['timestep-data-' + gather_url]);
-            } catch(SyntaxError) {
-                window.dataTables = {};
-            }
-        } else {
-            window.dataTables = {}
-        }
-    }
-
-    $(window).on('beforeunload',persistTableData);
-    restoreTableData();
+    window.dataTables = {}
     window.gather_url = gather_url
 }
 
+function getGatherUrl(typetag, miniLanguageQuery) {
+    return gather_url+"/gather/"+typetag+"/"+uriEncodeQuery(miniLanguageQuery)+".json";
+}
 
 function requestColumnData(editable_tag, miniLanguageQuery, callback) {
     if(window.dataTables === undefined ) {
@@ -45,7 +30,7 @@ function requestColumnData(editable_tag, miniLanguageQuery, callback) {
         console.log("Requesting "+miniLanguageQuery+" for "+editable_tag+"...");
         $.ajax({
             type: "GET",
-            url: gather_url + uriEncodeQuery(miniLanguageQuery) + ".json",
+            url: getGatherUrl(editable_tag, miniLanguageQuery),
             success: function (data) {
                 if(updateMarker!==undefined) {
                     let reqs = updateMarker.data("pending-requests")

--- a/tangos/web/static/timestepdata.js
+++ b/tangos/web/static/timestepdata.js
@@ -1,12 +1,14 @@
 
 
-function setupTimestepTables(gather_url) {
-    window.dataTables = {}
-    window.gather_url = gather_url
+function setupTimestepTables(timestep_url) {
+    if(timestep_url!==window.timestep_url) {
+        window.dataTables = {}
+        window.timestep_url = timestep_url
+    }
 }
 
 function getGatherUrl(typetag, miniLanguageQuery) {
-    return gather_url+"/gather/"+typetag+"/"+uriEncodeQuery(miniLanguageQuery)+".json";
+    return timestep_url+"/gather/"+typetag+"/"+uriEncodeQuery(miniLanguageQuery)+".json";
 }
 
 function requestColumnData(editable_tag, miniLanguageQuery, callback) {
@@ -64,16 +66,17 @@ function getFilterArray(object_tag, get_id_from='th', callbackAfterFetch = undef
     });
 
 
-    $.each(columnsToFilterOn, function() {
-       if(window.dataTables[object_tag][this]!==undefined) {
-           dataToFilterOn.push(window.dataTables[object_tag][this].data_formatted);
-       } else {
+    for(i=0; i<columnsToFilterOn.length; i++) {
+        col = columnsToFilterOn[i];
+        if(window.dataTables[object_tag][col]!==undefined) {
+           dataToFilterOn.push(window.dataTables[object_tag][col].data_formatted);
+        } else {
            if (callbackAfterFetch!==undefined) {
-               requestColumnData(object_tag, this, callbackAfterFetch);
+               requestColumnData(object_tag, col, callbackAfterFetch);
                return undefined;
            } // if no callback supplied, we carry on and get the best answer we can
-       }
-    });
+        }
+    }
 
     let nData = 0;
 

--- a/tangos/web/static/timestepdata.js
+++ b/tangos/web/static/timestepdata.js
@@ -25,7 +25,7 @@ function requestColumnData(editable_tag, miniLanguageQuery, callback) {
     if(window.dataTables[editable_tag][miniLanguageQuery] === undefined) {
         var updateMarker = $("#update-marker-" + editable_tag);
         if(updateMarker!==undefined)
-            updateMarker.html("<img src='/static/spinner.gif'>");
+            updateMarker.html("<div class='progress-spinner'></div>");
         let reqs = updateMarker.data("pending-requests")
         if (reqs === undefined) reqs = 0;
         updateMarker.data("pending-requests", reqs + 1)

--- a/tangos/web/static/timestepdata.js
+++ b/tangos/web/static/timestepdata.js
@@ -1,0 +1,114 @@
+
+
+function setupTimestepTables(gather_url) {
+    function persistTableData() {
+        sessionStorage['timestep-data-'+gather_url] =JSON.stringify(window.dataTables);
+    }
+
+    function restoreTableData() {
+        if(sessionStorage['timestep-data-'+gather_url] !== undefined)
+        {
+            try {
+                window.dataTables = JSON.parse(sessionStorage['timestep-data-' + gather_url]);
+            } catch(SyntaxError) {
+                window.dataTables = {};
+            }
+        } else {
+            window.dataTables = {}
+        }
+    }
+
+    $(window).on('beforeunload',persistTableData);
+    restoreTableData();
+    window.gather_url = gather_url
+}
+
+
+function requestColumnData(editable_tag, miniLanguageQuery, callback) {
+    if(window.dataTables === undefined ) {
+        console.log("Attempt to request column data but the data tables have not yet been initialised")
+        return undefined; // can't do anything useful
+    }
+
+    if(window.dataTables[editable_tag] === undefined) {
+        window.dataTables[editable_tag] = {}
+    }
+
+
+    if(window.dataTables[editable_tag][miniLanguageQuery] === undefined) {
+        var updateMarker = $("#update-marker-" + editable_tag);
+        if(updateMarker!==undefined)
+            updateMarker.html("<img src='/static/spinner.gif'>");
+        let reqs = updateMarker.data("pending-requests")
+        if (reqs === undefined) reqs = 0;
+        updateMarker.data("pending-requests", reqs + 1)
+        console.log("Requesting "+miniLanguageQuery+" for "+editable_tag+"...");
+        $.ajax({
+            type: "GET",
+            url: gather_url + uriEncodeQuery(miniLanguageQuery) + ".json",
+            success: function (data) {
+                if(updateMarker!==undefined) {
+                    let reqs = updateMarker.data("pending-requests")
+                    if (reqs === 1)
+                        $("#update-marker-" + editable_tag).html('');
+                    updateMarker.data("pending-requests", reqs - 1)
+                }
+                window.dataTables[editable_tag][miniLanguageQuery] = data;
+                if(callback!==undefined)
+                   callback(window.dataTables[editable_tag][miniLanguageQuery]);
+            }
+        });
+    } else {
+        if(callback!==undefined)
+            callback(window.dataTables[editable_tag][miniLanguageQuery]);
+    }
+
+}
+
+function getFilterArray(object_tag, get_id_from='th', callbackAfterFetch = undefined) {
+    let columnsToFilterOn = [];
+    let dataToFilterOn = [];
+
+    const re = /filter-(.*)/;
+    $('#properties_form_'+object_tag+' input[type="checkbox"]').each(function() {
+        let $this = $(this);
+        if($this.prop('checked') && $this.is(":visible")) {
+            let name = $this.attr('name').match(re)[1];
+            columnsToFilterOn.push(uriDecodeQuery(name));
+        }
+    });
+
+
+    $.each(columnsToFilterOn, function() {
+       if(window.dataTables[object_tag][this]!==undefined) {
+           dataToFilterOn.push(window.dataTables[object_tag][this].data_formatted);
+       } else {
+           if (callbackAfterFetch!==undefined) {
+               requestColumnData(object_tag, this, callbackAfterFetch);
+               return undefined;
+           } // if no callback supplied, we carry on and get the best answer we can
+       }
+    });
+
+    let nData = 0;
+
+    try {
+        nData = window.dataTables[object_tag]['halo_number()'].data_formatted.length;
+    } catch(TypeError) {
+        if (callbackAfterFetch!==undefined) {
+
+           requestColumnData(object_tag, 'halo_number()', callbackAfterFetch);
+       } // if no callback supplied, we carry on and get the best answer we can
+        return undefined;
+    }
+
+    let filterArray = new Array(nData).fill(true);
+
+    $.each(dataToFilterOn, function (j, c) {
+        for(var i=0; i<nData; i++) {
+            if (c[i] !== 'True') filterArray[i] = false;
+        }
+    });
+
+    return filterArray;
+}

--- a/tangos/web/templates/halo_view.jinja2
+++ b/tangos/web/templates/halo_view.jinja2
@@ -3,7 +3,7 @@
 {% block content %}
     <!-- Following are hidden elements to allow scripts to fetch new information -->
     <div id="calculate_url" class="dynamic-update hidden">{{ calculate_url }}</div>
-    <div id="gather_url" class="dynamic-update hidden">{{ gather_url }}</div>
+    <div id="timestep_url" class="dynamic-update hidden">{{ timestep_url }}</div>
     <div id="calculate_all_url" class="dynamic-update hidden">{{ calculate_all_url }}</div>
     <div id="cascade_url" class="dynamic-update hidden">{{ cascade_url }}</div>
     <div id="tree_url" class="dynamic-update hidden">{{ tree_url }}</div>

--- a/tangos/web/templates/halo_view.jinja2
+++ b/tangos/web/templates/halo_view.jinja2
@@ -4,8 +4,10 @@
     <!-- Following are hidden elements to allow scripts to fetch new information -->
     <div id="calculate_url" class="dynamic-update hidden">{{ calculate_url }}</div>
     <div id="gather_url" class="dynamic-update hidden">{{ gather_url }}</div>
+    <div id="calculate_all_url" class="dynamic-update hidden">{{ calculate_all_url }}</div>
     <div id="cascade_url" class="dynamic-update hidden">{{ cascade_url }}</div>
     <div id="tree_url" class="dynamic-update hidden">{{ tree_url }}</div>
+    <div id="halo_number" class="dynamic-update hidden">{{ halo_number }}</div>
     <div id="object_typetag" class="dynamic-update hidden">{{ halo_typetag }}</div>
 
     <h1 class="dynamic-update" id="halo-title">{{ halo_typetag  }} {{ halo_number }} of {{ timestep }}</h1>
@@ -24,12 +26,8 @@
                   </td>
                 </tr>
                <tr><td>Look at another {{ halo_typetag }}:</td>
-               <td>
-                    {% if halo_number>1 %}
-                       <a href="{{ gather_url }}{{ halo_typetag }}_{{ halo_number-1 }}" class="ajaxenabled">{{ halo_number-1 }}</a> |
-                    {% endif %} {{ halo_number }} |
-                    <a href="{{ gather_url }}{{ halo_typetag }}_{{ halo_number+1 }}" class="ajaxenabled">{{ halo_number+1 }}</a>
-               </td></tr>
+               <td id="nav-to-another"><img src="/static/spinner.gif"></td>
+               </tr>
             <tr><td><label for="target_sim_id">Find in another simulation:</label></td>
             <td><select name="target_sim_id" id="target_sim_id" onchange="findInOtherSimulation();">
                         {% for sim in all_simulations %}
@@ -114,7 +112,6 @@
     </div>
     </form>
 
-
+    <script type="text/javascript" src="{{ request.static_url('tangos.web:static/timestepdata.js') }}"></script>
     <script type="text/javascript" src="{{ request.static_url('tangos.web:static/halo_view.js') }}"></script>
-
 {% endblock content %}

--- a/tangos/web/templates/timestep_view.jinja2
+++ b/tangos/web/templates/timestep_view.jinja2
@@ -1,8 +1,8 @@
 {% extends "layout.jinja2" %}
 
-{% macro make_table(objects, object_type) %}
+{% macro make_table(object_type) %}
     <form id="properties_form_{{ object_type }}" class="autorestore">
-        <p>Page
+        <p><span id="update-marker-{{ object_type }}"></span>Page
             <select name="page" id="page-{{ object_type }}">
                 <option value="1" selected>1</option>
             </select> of <span id="num-pages-{{ object_type }}">1</span>.
@@ -18,7 +18,7 @@
             <tr id="header-row-{{ object_type }}">
                 <th id="header-number-{{ object_type }}">Number</th>
                 <th class="editable" id="header-colid-1-{{ object_type }}"></th>
-                <th id="header-go-{{ object_type }}">Go</th>
+                <th id="header-go-{{ object_type }}">Go &rarr;</th>
             </tr>
             <tr>
                 <th></th>
@@ -26,60 +26,24 @@
                 <th></th>
             </tr>
 
-        <script>
-            if(window.dataTables['{{  object_type }}']===undefined) {
-                window.dataTables['{{ object_type }}'] = {}
-                window.dataTables['{{ object_type }}']['*halo_number'] = Object();
-                window.dataTables['{{ object_type }}']['*halo_number'].data_formatted = [
-                    {% for h in objects %}
-                        {{ h.halo_number }},
-                    {% endfor %}
-                ];
-                window.dataTables['{{ object_type }}']['*go_link'] = Object();
-                window.dataTables['{{ object_type }}']['*go_link'].data_formatted = [
-                    {% for h in objects %}
-                        '<a href="{{ h.url }}">Go &rarr;</a>',
-                    {% endfor %}
-                ];
-            }  // otherwise it has been restored from session storage.
-        </script>
 
         </table>
     </form>
 {% endmacro %}
 
 {% block content %}
+    <script type="text/javascript" src="{{ request.static_url('tangos.web:static/timestepdata.js') }}"></script>
 
-    <script>
-
-    function persistTableData() {
-        sessionStorage['timestep-data-'+window.location.href] =JSON.stringify(window.dataTables);
-    }
-
-    function restoreTableData() {
-        if(sessionStorage['timestep-data-'+window.location.href]!==undefined)
-        {
-            window.dataTables = JSON.parse(sessionStorage['timestep-data-'+window.location.href])
-        } else {
-            window.dataTables = {}
-        }
-    }
-
-    $(window).on('beforeunload',persistTableData);
-    restoreTableData();
-
-
-    </script>
     <h1>Timestep: {{ timestep }}</h1>
 
     <table id="objects-container"><tr>
 
     {% for this_object in objects %}
-        {%  if len(this_object['items'])>0 %}
+        {%  if this_object['n_items']>0 %}
         <td>
             <h2>{{ this_object['title'] }}</h2>
 
-            {{ make_table(this_object['items'], this_object['typetag']) }}
+            {{ make_table(this_object['typetag']) }}
         </td>
         {% endif %}
     {% endfor %}
@@ -102,29 +66,24 @@ $.fn.markAsColumnInsertPoint = function(editable_tag) {
 }
 
 
+
 function updateColumnData(miniLanguageQuery, columnId, editable_tag) {
 
     $('#header-'+columnId).data('miniLanguageQuery', miniLanguageQuery);
 
     if(window.dataTables[editable_tag][miniLanguageQuery]!==undefined) {
         data = window.dataTables[editable_tag][miniLanguageQuery]
-        $('#header-' + columnId).html(miniLanguageQuery);
-        updatePlotControlElements('#plotctl-' + columnId, miniLanguageQuery, false, data.can_use_as_filter, false, true);
+        if (data===undefined || data.error) {
+            $('#header-' + columnId).html("<span class='load_table_failed'>" + miniLanguageQuery + " (failed)</span>")
+        } else {
+            $('#header-' + columnId).html(miniLanguageQuery);
+            updatePlotControlElements('#plotctl-' + columnId, miniLanguageQuery, false, data.can_use_as_filter, false, true);
+        }
     } else {
         $('#header-'+columnId).html("<img src='/static/spinner.gif'/>"+miniLanguageQuery);
         updatePlotControlElements('#plotctl-' + columnId, miniLanguageQuery, false, false, false);
-        $.ajax({
-            type: "GET",
-            url: "{{ gather_url }}" + uriEncodeQuery(miniLanguageQuery) + ".json",
-            success: function (data) {
-                if (data===undefined || data.error) {
-                    $('#header-' + columnId).html("<span class='load_table_failed'>" + miniLanguageQuery + " (failed)</span>")
-                } else {
-                    window.dataTables[editable_tag][miniLanguageQuery] = data;
-                    updateColumnData(miniLanguageQuery, columnId, editable_tag);
-                }
-
-            }
+        requestColumnData(editable_tag, miniLanguageQuery, function() {
+            updateColumnData(miniLanguageQuery, columnId, editable_tag);
         });
     }
     updateTableDisplay(editable_tag);
@@ -152,69 +111,76 @@ function removeColumn(name, object_tag) {
 
 function setupDynamicTables() {
 
+    setupTimestepTables('{{ gather_url }}');
+
     {% for this_object in objects %}
-        $('#header-number-{{ this_object['typetag'] }}').data('miniLanguageQuery', "*halo_number");
+        if(window.dataTables['{{ this_object['typetag'] }}']===undefined) {
+            window.dataTables['{{ this_object['typetag'] }}'] = {};
+        }
+
+        $('#header-number-{{ this_object['typetag'] }}').data('miniLanguageQuery', "halo_number()");
         $('#header-go-{{ this_object['typetag'] }}').data('miniLanguageQuery', "*go_link");
         $('#header-colid-1-{{ this_object["typetag"] }}').markAsColumnInsertPoint('{{ this_object["typetag"] }}');
         updateTableDisplay('{{ this_object['typetag']  }}');
+        requestColumnData('{{ this_object["typetag"] }}', "halo_number()", function() {
+            let tables = window.dataTables['{{ this_object["typetag"]  }}'];
+            let numbers = tables['halo_number()'].data_formatted;
+            let links = new Array(numbers.length);
+            for(i=0; i<numbers.length; i++) {
+                links[i] = `<a href="{{ this_object["object_url"] }}${numbers[i]}">Go &rarr;</a>`
+            }
+            tables['*go_link'] = Object();
+            tables['*go_link'].data_formatted = links;
+            updateTableDisplay('{{ this_object['typetag']  }}');
+        })
     {% endfor %}
 
 }
 
+
+
 function updateTableDisplay(object_tag) {
-    var columnsToFilterOn = [];
-    var dataToFilterOn = [];
-
-    var re = new RegExp("plotctl-(.*)");
-    $('#properties_form_'+object_tag+' input[type="checkbox"]').each(function() {
-        var $this = $(this);
-        if($this.prop('checked') && $this.is(":visible")) {
-            var control_id = $this.closest('th').attr('id');
-            var column_id = re.exec(control_id)[1];
-            columnsToFilterOn.push("header-"+column_id);
-        }
-    });
-
-    $("#table-"+object_tag+" tr.tangos-data").remove();
-
-    var columns = [];
+    let dataColumns = [];
     $("tr#header-row-"+object_tag+" th").each(function() {
        var miniLanguageQ = $(this).data('miniLanguageQuery');
        if(window.dataTables[object_tag][miniLanguageQ]!==undefined) {
-           columns.push(window.dataTables[object_tag][miniLanguageQ].data_formatted);
-           if (columnsToFilterOn.includes(this.id)) {
-               dataToFilterOn.push(window.dataTables[object_tag][miniLanguageQ].data_formatted);
-           }
+           dataColumns.push(window.dataTables[object_tag][miniLanguageQ].data_formatted);
        } else {
-           columns.push(undefined);
+           dataColumns.push(undefined);
        }
     });
 
-    var nData = 0;
-    $.each(columns, function(i,c) {
+    let nData = 0;
+    $.each(dataColumns, function(i,c) {
         if(c !== undefined && c.length>nData) {
             nData=c.length;
         }
     });
 
 
-    var rowsPerPage = parseInt($("#per-page-"+object_tag+" option:selected").text());
-    var page = parseInt($("#page-"+object_tag+" option:selected").text());
-    var startRow = (page-1)*rowsPerPage;
-    var endRow = startRow+rowsPerPage;
+    $("#table-"+object_tag+" tr.tangos-data").remove();
 
-    var nRowsTotal=0;
-    var displayRows = [];
+    let filterArray = getFilterArray(object_tag);
+
+    let rowsPerPage = parseInt($("#per-page-"+object_tag+" option:selected").text());
+    let page = parseInt($("#page-"+object_tag+" option:selected").text());
+    if (isNaN(page)) page=1;
+    let startRow = (page-1)*rowsPerPage;
+    let endRow = startRow+rowsPerPage;
+
+    let nRowsTotal=0;
+    let displayRows = [];
 
     for(var i=0; i<nData; i++) {
-        var shouldDisplay = true;
-        $.each(dataToFilterOn, function(j,c) {
-            if(c[i] !== 'True') shouldDisplay = false;
-        });
+        let shouldDisplay = true;
+
+        if(filterArray!==undefined)
+            shouldDisplay = filterArray[i];
+
         if(shouldDisplay) {
             if (nRowsTotal<endRow && nRowsTotal>=startRow) {
                 display = "<tr class='tangos-data'>"
-                $.each(columns, function(j,c) {
+                $.each(dataColumns, function(j,c) {
                     if(c!==undefined)
                         display+="<td>"+c[i]+"</td>";
                     else
@@ -241,6 +207,8 @@ function updateTableDisplay(object_tag) {
     }
 
     $("#table-"+object_tag).append(displayRows);
+
+
 
 
 }

--- a/tangos/web/templates/timestep_view.jinja2
+++ b/tangos/web/templates/timestep_view.jinja2
@@ -80,7 +80,7 @@ function updateColumnData(miniLanguageQuery, columnId, editable_tag) {
             updatePlotControlElements('#plotctl-' + columnId, miniLanguageQuery, false, data.can_use_as_filter, false, true);
         }
     } else {
-        $('#header-'+columnId).html("<img src='/static/spinner.gif'/>"+miniLanguageQuery);
+        $('#header-'+columnId).html("<div class='progress-spinner'></div>"+miniLanguageQuery);
         updatePlotControlElements('#plotctl-' + columnId, miniLanguageQuery, false, false, false);
         requestColumnData(editable_tag, miniLanguageQuery, function() {
             updateColumnData(miniLanguageQuery, columnId, editable_tag);

--- a/tangos/web/templates/timestep_view.jinja2
+++ b/tangos/web/templates/timestep_view.jinja2
@@ -111,7 +111,7 @@ function removeColumn(name, object_tag) {
 
 function setupDynamicTables() {
 
-    setupTimestepTables('{{ gather_url }}');
+    setupTimestepTables('{{ timestep_url }}');
 
     {% for this_object in objects %}
         if(window.dataTables['{{ this_object['typetag'] }}']===undefined) {

--- a/tangos/web/views/halo_data.py
+++ b/tangos/web/views/halo_data.py
@@ -14,6 +14,7 @@ from ... import core
 from ...config import webview_default_image_format
 import threading
 import time
+import functools
 
 _matplotlib_lock = threading.RLock()
 
@@ -102,6 +103,7 @@ def elements_are_arrays(data_array):
         return False
     else:
         return is_array(data_array[0])
+
 
 @view_config(route_name='calculate_all', renderer='json')
 def calculate_all(request):

--- a/tangos/web/views/halo_data.py
+++ b/tangos/web/views/halo_data.py
@@ -105,13 +105,13 @@ def elements_are_arrays(data_array):
         return is_array(data_array[0])
 
 
-@view_config(route_name='calculate_all', renderer='json')
+@view_config(route_name='calculate_all', renderer='json', http_cache=3600)
 def calculate_all(request):
     ts = timestep_from_request(request)
-
+    typetag = request.matchdict['typetag']
     try:
         data, = ts.calculate_all(decode_property_name(request.matchdict['nameid']),
-                                 sanitize=False, order_by_halo_number=True)
+                                 sanitize=False, order_by_halo_number=True, object_type=typetag)
     except Exception as e:
         return {'error': getattr(e,'message',""), 'error_class': type(e).__name__}
 

--- a/tangos/web/views/halo_view.py
+++ b/tangos/web/views/halo_view.py
@@ -127,7 +127,6 @@ def halo_view(request):
             'tree_url': request.route_url('merger_tree',simid=request.matchdict['simid'],
                                             timestepid=request.matchdict['timestepid'],
                                             halonumber=request.matchdict['halonumber']),
-            'gather_url': request.route_url('timestep_view',simid=request.matchdict['simid'],
+            'timestep_url': request.route_url('timestep_view',simid=request.matchdict['simid'],
                                             timestepid=request.matchdict['timestepid']),
-            'timestep_url': "/%s/%s/" % (sim.escaped_basename, ts.escaped_extension),
             'cascade_url': "/%s/%s/%s/"%(sim.escaped_basename,ts.escaped_extension,halo.basename)}

--- a/tangos/web/views/halo_view.py
+++ b/tangos/web/views/halo_view.py
@@ -127,5 +127,8 @@ def halo_view(request):
             'tree_url': request.route_url('merger_tree',simid=request.matchdict['simid'],
                                             timestepid=request.matchdict['timestepid'],
                                             halonumber=request.matchdict['halonumber']),
-            'gather_url': "/%s/%s/"%(sim.escaped_basename,ts.escaped_extension),
+            'gather_url': request.route_url('calculate_all',simid=request.matchdict['simid'],
+                                            timestepid=request.matchdict['timestepid'],
+                                            nameid="")[:-5],
+            'timestep_url': "/%s/%s/" % (sim.escaped_basename, ts.escaped_extension),
             'cascade_url': "/%s/%s/%s/"%(sim.escaped_basename,ts.escaped_extension,halo.basename)}

--- a/tangos/web/views/halo_view.py
+++ b/tangos/web/views/halo_view.py
@@ -127,8 +127,7 @@ def halo_view(request):
             'tree_url': request.route_url('merger_tree',simid=request.matchdict['simid'],
                                             timestepid=request.matchdict['timestepid'],
                                             halonumber=request.matchdict['halonumber']),
-            'gather_url': request.route_url('calculate_all',simid=request.matchdict['simid'],
-                                            timestepid=request.matchdict['timestepid'],
-                                            nameid="")[:-5],
+            'gather_url': request.route_url('timestep_view',simid=request.matchdict['simid'],
+                                            timestepid=request.matchdict['timestepid']),
             'timestep_url': "/%s/%s/" % (sim.escaped_basename, ts.escaped_extension),
             'cascade_url': "/%s/%s/%s/"%(sim.escaped_basename,ts.escaped_extension,halo.basename)}

--- a/tangos/web/views/merger_tree.py
+++ b/tangos/web/views/merger_tree.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from pyramid.view import view_config
 from . import halo_from_request
 from ...relation_finding import tree
+from ...config import webview_cache_time
 
 class WebMergerTree(tree.MergerTree):
     def __init__(self, halo, request):
@@ -33,7 +34,7 @@ def _construct_mergertree(halo, request):
     return tree._treedata
 
 
-@view_config(route_name='merger_tree', renderer='json')
+@view_config(route_name='merger_tree', renderer='json', http_cache=webview_cache_time)
 def merger_tree(request):
     halo = halo_from_request(request)
     return {'tree': _construct_mergertree(halo, request)}

--- a/tangos/web/views/timestep_view.py
+++ b/tangos/web/views/timestep_view.py
@@ -6,10 +6,6 @@ from . import timestep_from_request
 import tangos
 from tangos import core
 
-def add_urls(halos, request, sim, ts):
-    for h in halos:
-        h.url = request.route_url('halo_view', simid=sim.escaped_basename, timestepid=ts.escaped_extension,
-                                  halonumber=h.basename)
 
 @view_config(route_name='timestep_view', renderer='../templates/timestep_view.jinja2')
 def timestep_view(request):
@@ -25,9 +21,9 @@ def timestep_view(request):
         except ValueError:
             break
 
-        objects = request.dbsession.query(core.Halo).\
-            filter_by(timestep_id=ts.id, object_typecode=typecode).order_by(core.Halo.halo_number).all()
-        add_urls(objects, request, sim, ts)
+        n_objects = request.dbsession.query(core.Halo).\
+            filter_by(timestep_id=ts.id, object_typecode=typecode).order_by(core.Halo.halo_number).count()
+
         title = core.Halo.class_from_tag(typetag).__name__+"s"
 
         if title=="BHs":
@@ -35,8 +31,12 @@ def timestep_view(request):
         elif title=="PhantomHalos":
             title="Phantom halos"
 
-        all_objects.append({'title': title, 'typetag': typetag, 'items': objects})
-        print(typecode, title, len(objects))
+        if n_objects>0:
+            all_objects.append({'title': title, 'typetag': typetag, 'n_items': n_objects,
+                                'object_url': request.route_url('halo_view',simid=sim.escaped_basename, timestepid=ts.escaped_extension,
+                                                                halonumber=typetag+"_")
+                                })
+
         typecode+=1
 
 

--- a/tangos/web/views/timestep_view.py
+++ b/tangos/web/views/timestep_view.py
@@ -42,6 +42,5 @@ def timestep_view(request):
 
     return {'timestep': ts.extension,
             'objects': all_objects,
-            'gather_url': request.route_url('calculate_all',simid=request.matchdict['simid'],
-                                            timestepid=request.matchdict['timestepid'],
-                                            nameid="")[:-5]}
+            'gather_url': request.route_url('timestep_view',simid=request.matchdict['simid'],
+                                            timestepid=request.matchdict['timestepid'])}

--- a/tangos/web/views/timestep_view.py
+++ b/tangos/web/views/timestep_view.py
@@ -42,5 +42,5 @@ def timestep_view(request):
 
     return {'timestep': ts.extension,
             'objects': all_objects,
-            'gather_url': request.route_url('timestep_view',simid=request.matchdict['simid'],
+            'timestep_url': request.route_url('timestep_view',simid=request.matchdict['simid'],
                                             timestepid=request.matchdict['timestepid'])}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -109,7 +109,7 @@ def test_image_plot():
     assert response.content_type == 'image/png'
 
 def test_json_gather_float():
-    response = app.get("/sim/ts1/gather/test_value.json")
+    response = app.get("/sim/ts1/gather/halo/test_value.json")
     assert response.content_type == 'application/json'
     assert response.status_int == 200
     result = json.loads(response.body.decode('utf-8'))
@@ -120,7 +120,7 @@ def test_json_gather_float():
     assert result['is_array'] is False
 
 def test_json_gather_array():
-    response = app.get("/sim/ts1/gather/test_image.json")
+    response = app.get("/sim/ts1/gather/halo/test_image.json")
     assert response.content_type == 'application/json'
     assert response.status_int == 200
     result = json.loads(response.body.decode('utf-8'))
@@ -131,7 +131,7 @@ def test_json_gather_array():
     assert result['is_array'] is True
 
 def test_json_gather_bool():
-    response = app.get("/sim/ts1/gather/has_property(test_image).json")
+    response = app.get("/sim/ts1/gather/halo/has_property(test_image).json")
     assert response.content_type == 'application/json'
     assert response.status_int == 200
     result = json.loads(response.body.decode('utf-8'))
@@ -166,7 +166,7 @@ def test_ordering_as_expected():
     assert (tangos.get_item("sim/ts4").calculate_all("halo_number()") == np.array([10,2,3])).all()
     assert (tangos.get_item("sim/ts4").calculate_all("halo_number()",order_by_halo_number=True) == np.array([2,3,10])).all()
 
-    response = app.get("/sim/ts4/gather/test_value.json")
+    response = app.get("/sim/ts4/gather/halo/test_value.json")
     assert response.content_type == 'application/json'
     assert response.status_int == 200
     result = json.loads(response.body.decode('utf-8'))


### PR DESCRIPTION
Web interface: when determining what the 'previous' and 'next' halos are, this patch uses the activated filters from the timestep view to offer only the relevant halos.