### PR TITLE
Support setting bounds to plots

### DIFF
--- a/tangos/web/static/halo_view.js
+++ b/tangos/web/static/halo_view.js
@@ -83,10 +83,19 @@ function getFilterUri () {
 }
 
 function getPlotUriOneVariable (name, extension) {
-  uri = $('#cascade_url').text() + name + '.' + extension
-  var plotformvals = $('#image_form').values()
-  if (plotformvals.logimage) { uri += '?logimage=1' }
-  return uri
+  let uri = $('#cascade_url').text() + name + '.' + extension
+  var plotformvals = {};
+  $('#image_form').serializeArray().forEach(val => {
+    plotformvals[val.name] = val.value;
+  });
+  let args = {};
+  if (plotformvals.logimage === "on") { args["logimage"] = 1 }
+  if (plotformvals.use_range === "on") {
+    if (Number(plotformvals.vmin) >= 0) { args["vmin"] = plotformvals.vmin }
+    if (Number(plotformvals.vmax) <= 100) { args["vmax"] = plotformvals.vmax }
+  }
+
+  return uri + "?" + $.param(args);
 }
 
 function getPlotUriTwoVariables (name1, name2, typetag, extension) {
@@ -152,7 +161,9 @@ function fetchPlot (isUpdate) {
   var namethis = formvals.justthis
   var extension = $('#image_format').val()
   var uri
-  if (namethis !== undefined) { uri = getPlotUriOneVariable(namethis, extension) } else {
+  if (namethis !== undefined) { 
+    uri = getPlotUriOneVariable(namethis, extension) 
+  } else {
     if (name1 === undefined || name2 === undefined) { return }
 
     uri = getPlotUriTwoVariables(name1, name2, formvals.object_typetag, extension)
@@ -218,6 +229,20 @@ function plotSelectionUpdate () {
   ensurePlotTypeIsNotTree()
   fetchPlot(true)
 }
+
+
+function rangeDisplay(element) {
+  if ($(element).is(':checked')) {
+    $("#vmin-vmax-range").show();
+  } else {
+    $("#vmin-vmax-range").hide();
+  }
+}
+
+$('#use_range').click(function(){
+  rangeDisplay(this);
+});
+rangeDisplay($("#use_range"));
 
 $('#nametg-custom-row-1').markAsRowInsertPoint()
 ajaxEnableLinks()

--- a/tangos/web/templates/halo_view.jinja2
+++ b/tangos/web/templates/halo_view.jinja2
@@ -74,9 +74,9 @@
             <input type="checkbox" name="use_range" id="use_range" onclick="rangeDisplay()"/><label for="use_range">Use range</label>
             <p id="vmin-vmax-range">
                 <label for="vmin">Vmin</label>
-                <input name="vmin" type="range" id="vmin" min="-1", vmax="100" value="-1" onchange="fetchPlot()">
+                <input name="vmin" type="range" id="vmin" min="0", vmax="100" value="0" onchange="fetchPlot()">
                 <label for="vmax">Vmax</label>
-                <input name="vmax" type="range" id="vmax" min="0", vmax="101" value="100" onchange="fetchPlot()">
+                <input name="vmax" type="range" id="vmax" min="0", vmax="100" value="100" onchange="fetchPlot()">
             </p>
             <span class="download-area-csv"><a href="#" id="download-csv-link">&#x25BC; Download CSV</a></span>
             <span class="download-area-tree"><a href="#" id="download-merger-tree">&#x25BC; Download Merger Tree</a></span>

--- a/tangos/web/templates/halo_view.jinja2
+++ b/tangos/web/templates/halo_view.jinja2
@@ -71,6 +71,13 @@
                 <option value='pdf'>PDF</option>
             </select>
             <input name="logimage" type="checkbox" id="logimage"/><label for="logimage">log images</label>.
+            <input type="checkbox" name="use_range" id="use_range" onclick="rangeDisplay()"/><label for="use_range">Use range</label>
+            <p id="vmin-vmax-range">
+                <label for="vmin">Vmin</label>
+                <input name="vmin" type="range" id="vmin" min="-1", vmax="100" value="-1" onchange="fetchPlot()">
+                <label for="vmax">Vmax</label>
+                <input name="vmax" type="range" id="vmax" min="0", vmax="101" value="100" onchange="fetchPlot()">
+            </p>
             <span class="download-area-csv"><a href="#" id="download-csv-link">&#x25BC; Download CSV</a></span>
             <span class="download-area-tree"><a href="#" id="download-merger-tree">&#x25BC; Download Merger Tree</a></span>
         </form>


### PR DESCRIPTION
This adds the possibility to add bounds to plots.

From the UI, it is possible to set bounds based on the percentile of the image (0 being the minimum and 100 the maximum) with sliders. I also added a feature to use absolute boundaries which currently cannot be used from the UI, as it would require communicating the image bounds from the server to the UI.

I also fixed incorrect labelling of the colorbar for log plot of images : the image was plotted in log scale but this information was missing from the plot (and in particular the colorbar). This is fixed by using matplotlib's normalization features.

Here is what it looks like:

| With range | Without range |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/5411875/113702695-26a02b00-96da-11eb-819c-be29409ce7e4.png) | ![image](https://user-images.githubusercontent.com/5411875/113702810-4d5e6180-96da-11eb-91b8-77c1acca35e5.png) 
|


