### PR TITLE
Attempt to fix AHF long integer issue

### DIFF
--- a/tangos/core/halo.py
+++ b/tangos/core/halo.py
@@ -24,7 +24,7 @@ class UnsignedInteger(types.TypeDecorator):
         return np.uint64(value).astype(np.int64)
 
     def process_result_value(self, value, dialect):
-        return int(np.int64(value).astype(np.uint64))
+        return np.frombuffer(value, dtype=np.uint64)[0]
 
 
 class Halo(Base):

--- a/tangos/core/halo.py
+++ b/tangos/core/halo.py
@@ -24,8 +24,10 @@ class UnsignedInteger(types.TypeDecorator):
         return np.uint64(value).astype(np.int64)
 
     def process_result_value(self, value, dialect):
-        return np.frombuffer(value, dtype=np.uint64)[0]
-
+        if value:
+            return np.frombuffer(value, dtype=np.uint64)[0]
+        else:
+            return None
 
 class Halo(Base):
     __tablename__= "halos"

--- a/tests/test_big_integer_halos.py
+++ b/tests/test_big_integer_halos.py
@@ -18,3 +18,7 @@ def test_big_integer_halo():
     session.add(h)
     session.commit()
 
+    h = db.get_halo("sim/ts1/1")
+
+    assert h.finder_id == crazy_number
+

--- a/tests/test_big_integer_halos.py
+++ b/tests/test_big_integer_halos.py
@@ -1,0 +1,20 @@
+from tangos.core import Halo
+from tangos import testing
+import tangos as db
+import tangos.testing.simulation_generator
+import numpy as np
+
+def setup():
+    testing.init_blank_db_for_testing()
+    creator = testing.simulation_generator.TestSimulationGenerator()
+    creator.add_timestep()
+
+def test_big_integer_halo():
+    crazy_number = np.iinfo(np.dtype('uint64')).max - 10 # close to maximum but not the actual max, avoiding special case
+
+    h  = Halo(db.get_timestep("sim/ts1"),1,crazy_number,1,0,0,0)
+    session = db.core.get_default_session()
+
+    session.add(h)
+    session.commit()
+


### PR DESCRIPTION
Some versions of AHF generates internal unsigned long halo numbers,
but SQLite can only store signed longs (8-bit maximum). This leads
to overflow errors when generating a database.

Since ordering is unimportant, a hack to fix this may be to take the
bit pattern and turn it into a signed integer before storing.