### PR TITLE
Simplify get_simulation_property to always use SharedLock

### DIFF
--- a/tangos/properties/__init__.py
+++ b/tangos/properties/__init__.py
@@ -50,16 +50,13 @@ class PropertyCalculation(six.with_metaclass(PropertyCalculationMetaClass,object
     def all_classes(cls):
         return cls._all_classes
 
-    def __init__(self, simulation, use_database_lock=False):
+    def __init__(self, simulation):
         """Initialise a PropertyCalculation calculation object
 
         :param simulation: The simulation from which the properties will be derived
         :type simulation: tangos.core.simulation.Simulation
-
-        :param use_database_lock: If True,
         """
         self.__simulation = simulation
-        self.__use_database_lock = use_database_lock
         self.__simulation_property_cache = {}
         self.timing_monitor = timing_monitor.TimingMonitor()
 
@@ -89,10 +86,7 @@ class PropertyCalculation(six.with_metaclass(PropertyCalculationMetaClass,object
 
         This is safe to call even if the database might be locked.
         """
-        if self.__use_database_lock:
-            with parallel_tasks.lock.SharedLock("insert_list"):
-                return self.__simulation.get(name, default)
-        else:
+        with parallel_tasks.lock.SharedLock("insert_list"):
             return self.__simulation.get(name, default)
 
     @classmethod
@@ -484,22 +478,16 @@ def providing_classes(property_name_list, handler_class, silent_fail=False):
     return classes
 
 def instantiate_classes(simulation, property_name_list, silent_fail=False):
-    """Instantiate appropriate property calculation classes for a given simulation and list of property names.
-
-    Assumes that these will be used in a parallel_tasks session (most likely by the property_writer),
-    and accordingly activates the parallel_tasks database locking mechanism."""
+    """Instantiate appropriate property calculation classes for a given simulation and list of property names."""
     instances = []
     handler_class = type(simulation.get_output_handler())
     for property_identifier in property_name_list:
-        instances.append(providing_class(property_identifier, handler_class, silent_fail)(simulation, True))
+        instances.append(providing_class(property_identifier, handler_class, silent_fail)(simulation))
 
     return instances
 
 def instantiate_class(simulation, property_name, silent_fail=False):
-    """Instantiate an appropriate property calculation class for a given simulation and property name
-
-    Assumes that these will be used in a parallel_tasks session (most likely by the property_writer),
-    and accordingly activates the parallel_tasks database locking mechanism."""
+    """Instantiate an appropriate property calculation class for a given simulation and property name."""
     instance = instantiate_classes(simulation, [property_name], silent_fail)
     if len(instance)==0:
         return None

--- a/tangos/scripts/manager.py
+++ b/tangos/scripts/manager.py
@@ -296,9 +296,9 @@ def add_tracker(halo, size=None):
     core.get_default_session().commit()
 
 
-def grep_run(st):
+def grep_run(opts):
     run = core.get_default_session().query(Creator).filter(
-        Creator.command_line.like("%" + st + "%")).all()
+        Creator.command_line.like("%" + opts.query + "%")).all()
     for r in run:
         print(r.id, end=' ')
 
@@ -446,6 +446,12 @@ def get_argument_parser_and_subparsers():
     subparse_recentruns.set_defaults(func=list_recent_runs)
     subparse_recentruns.add_argument("num", type=int,
                                      help="The number of runs to display, starting with the most recent")
+
+    subparse_greprun = subparse.add_parser("grep-runs",
+                                              help="List IDs of runs matching command line")
+    subparse_greprun.set_defaults(func=grep_run)
+    subparse_greprun.add_argument("query", type=str,
+                                     help="The sub-string to search for in the command line")
 
     # The following subcommands currently do not work and is disabled:
     """


### PR DESCRIPTION
SharedLock does nothing when parallel_tasks is not initialised, so there is no point
making a meal out of whether get_simulation_property uses it or not.