### PR TITLE
Allowing importing arrays of numbers as Tangos Properties

### DIFF
--- a/tangos/tools/property_importer.py
+++ b/tangos/tools/property_importer.py
@@ -46,7 +46,8 @@ class PropertyImporter(GenericTangosTool):
             if np.issubdtype(value.dtype, np.number):
                 return core.halo_data.HaloProperty(object, name, value)
             else:
-                print(name, value)
+                logger.warn("Ignoring stat file entry key='%s' value='%s' as the value is not a number or an array of numbers",
+                        name.text, value)
         elif value is not None:
             logger.warn("Ignoring stat file entry key='%s' value='%s' as the value is not a number or an array of numbers",
                         name.text, value)

--- a/tangos/tools/property_importer.py
+++ b/tangos/tools/property_importer.py
@@ -39,12 +39,16 @@ class PropertyImporter(GenericTangosTool):
             value = value.relative_to_timestep_cache(self._object_cache).resolve(self._session)
             if value is not None:
                 return core.halo_data.HaloLink(object, value, name)
-        elif np.issubdtype(type(value), np.float) or np.issubdtype(type(value), np.integer):
+        elif isinstance(value, numbers.Number):
             return core.halo_data.HaloProperty(object, name, value)
+        elif isinstance(value, np.ndarray):
+            if np.issubdtype(value.dtype, np.number):
+                return core.halo_data.HaloProperty(object, name, value)
+            else:
+                print(name, value)
         elif value is not None:
-            logger.warn("Ignoring stat file entry key='%s' value='%s' as the value is not a number",
+            logger.warn("Ignoring stat file entry key='%s' value='%s' as the value is not a number or an array of numbers",
                         name.text, value)
-
         return None
 
     def _create_properties(self, name, object, values):

--- a/tangos/tools/property_importer.py
+++ b/tangos/tools/property_importer.py
@@ -8,6 +8,7 @@ from . import GenericTangosTool
 from ..util import proxy_object
 from ..util import timestep_object_cache
 import numpy as np
+import numbers
 
 class PropertyImporter(GenericTangosTool):
     tool_name = 'import-properties'


### PR DESCRIPTION
I believe this should address #156 and I added a test for some edge cases (I could not find an existing check of this behaviour in the existing testing base).

Let me know if you have any comments
Martin