### PR TITLE
Making pynbody+HOP backward compatible given the new file structure

### DIFF
--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -583,3 +583,4 @@ class ChangaUseIDLInputHandler(ChangaInputHandler):
     auxiliary_file_patterns = ["*.amiga.grp"]
 
 from . import caterpillar, eagle, ramsesHOP
+RamsesHOPInputHandler = ramsesHOP.RamsesHOPInputHandler


### PR DESCRIPTION
The latest update to the HOP handlers breaks previous databases generated with pynbody + normal HOP, that cannot find their handler anymore:
```
  File "/Users/martinrey/Documents/tangos/tangos/core/halo_data/property.py", line 67, in data
    return self.get_data_with_reassembly_options()
  File "/Users/martinrey/Documents/tangos/tangos/core/halo_data/property.py", line 70, in get_data_with_reassembly_options
    return extraction_patterns.HaloPropertyValueWithReassemblyOptionsGetter(*options).postprocess_data_objects([self])[0]
  File "/Users/martinrey/Documents/tangos/tangos/core/extraction_patterns.py", line 114, in postprocess_data_objects
    return [self._postprocess_one_result(o) for o in outputs]
  File "/Users/martinrey/Documents/tangos/tangos/core/extraction_patterns.py", line 114, in <listcomp>
    return [self._postprocess_one_result(o) for o in outputs]
  File "/Users/martinrey/Documents/tangos/tangos/core/extraction_patterns.py", line 130, in _postprocess_one_result
    self._infer_property_class(property_object)
  File "/Users/martinrey/Documents/tangos/tangos/core/extraction_patterns.py", line 125, in _infer_property_class
    self._providing_class = property_object.name.providing_class(property_object.halo.handler_class)
  File "/Users/martinrey/Documents/tangos/tangos/core/halo.py", line 135, in handler_class
    self._handler_class = self.timestep.simulation.output_handler_class
  File "/Users/martinrey/Documents/tangos/tangos/core/simulation.py", line 51, in output_handler_class
    self._handler_class = input_handlers.get_named_handler_class(self.get("handler", config.default_fileset_handler_class))
  File "/Users/martinrey/Documents/tangos/tangos/input_handlers/__init__.py", line 214, in get_named_handler_class
    output_class = getattr(output_module, handler.split('.')[1])
AttributeError: module 'tangos.input_handlers.pynbody' has no attribute 'RamsesHOPInputHandler'
```

Making sure the names are matched and backward compatible in the pynbody class seems to do the trick. As far as I can tell, this is the only aspect that was broken by PR #160 

Martin