### PR TITLE
Command-line tools for searching for and removing runs in bulk

### DIFF
--- a/tangos/scripts/manager.py
+++ b/tangos/scripts/manager.py
@@ -295,13 +295,46 @@ def add_tracker(halo, size=None):
         print("done")
     core.get_default_session().commit()
 
-
-def grep_run(opts):
-    run = core.get_default_session().query(Creator).filter(
+def grep_run_id(opts):
+    matching_runs = core.get_default_session().query(Creator).filter(
         Creator.command_line.like("%" + opts.query + "%")).all()
-    for r in run:
+    for r in matching_runs:
         print(r.id, end=' ')
-
+    print('\n')
+        
+def grep_run_info(opts):
+    matching_runs = core.get_default_session().query(Creator).filter(
+        Creator.command_line.like("%" + opts.query + "%")).all()
+    for r in matching_runs:
+        r.print_info()
+    return matching_runs
+        
+def grep_remove_runs(opts):
+    print('Will remove the following run(s): ')
+    matching_runs = grep_run_info(opts)
+    
+    # Always ask for confirmation, as this action could be very destructive
+    print("You want to delete everything created by the above run(s)?")
+    print(""">>> type "yes" to continue""")
+    
+    if input(":").lower() == "yes":
+        
+        for r, run in enumerate(matching_runs):
+            print('Removing run ',r+1,' of ',len(matching_runs))
+            
+            run.halolinks.delete()
+            run.halos.delete()
+            run.properties.delete()
+            run.timesteps.delete()
+            for s in run.simulations:
+                core.get_default_session().delete(s)
+            core.get_default_session().commit()
+            core.get_default_session().delete(run)
+            core.get_default_session().commit()
+                    
+        print("Done")
+    else:
+        print("aborted")
 
 def list_recent_runs(opts):
     n = opts.num
@@ -447,11 +480,24 @@ def get_argument_parser_and_subparsers():
     subparse_recentruns.add_argument("num", type=int,
                                      help="The number of runs to display, starting with the most recent")
 
-    subparse_greprun = subparse.add_parser("grep-runs",
-                                              help="List IDs of runs matching command line")
-    subparse_greprun.set_defaults(func=grep_run)
+    subparse_greprun = subparse.add_parser("grep-run-ids",
+                                          help="List IDs of runs matching command line input")
+    subparse_greprun.set_defaults(func=grep_run_id)
     subparse_greprun.add_argument("query", type=str,
                                      help="The sub-string to search for in the command line")
+                                     
+    subparse_grepruninfo = subparse.add_parser("grep-runs",
+                                          help="List details of runs matching command line input")
+    subparse_grepruninfo.set_defaults(func=grep_run_info)
+    subparse_grepruninfo.add_argument("query", type=str,
+                                     help="The sub-string to search for in the command line")
+                                                              
+    subparse_grepremove = subparse.add_parser("grep-remove",
+                                           help="Remove runs matching command line input")
+    subparse_grepremove.set_defaults(func=grep_remove_runs)
+    subparse_grepremove.add_argument("query", type=str,
+                                      help="The sub-string to search for in the command line")
+
 
     # The following subcommands currently do not work and is disabled:
     """


### PR DESCRIPTION
Several months ago we discussed adding some extra command-line tools for searching for tangos runs, and deleting them if desired. Here they are!

This modification renames the original "grep-runs" command to "grep-run-ids" to better suit its function. The "grep-runs" command now returns the full details of each of the runs matching the given string, which may include SQL wildcards such as "%" and "%".

Finally, there is a new "grep-remove" command, which will delete any runs matching the specified string, which is very useful for deleting whole simulations and large batches of changes to the database. The command first lists all the runs that will be deleted and always asks for confirmation from the user, as this command could potentially be very destructive.