### PR TITLE
Fix #172

### DIFF
--- a/tangos/__init__.py
+++ b/tangos/__init__.py
@@ -22,4 +22,4 @@ from .core import *
 from .query import *
 from . import properties
 
-__version__ = '1.5.1'
+__version__ = '1.5.2'

--- a/tangos/relation_finding/one_hop.py
+++ b/tangos/relation_finding/one_hop.py
@@ -147,7 +147,7 @@ class HopStrategy(object):
         halo_alias = None
         if self._ordering_requires_join():
             timestep_alias = sqlalchemy.orm.aliased(core.timestep.TimeStep)
-            halo_alias = sqlalchemy.orm.aliased(core.halo.Halo)
+            halo_alias = sqlalchemy.orm.aliased(core.halo.SimulationObjectBase)
             query = query.join(halo_alias, self._link_orm_class.halo_to_id == halo_alias.id).join(timestep_alias)
             query = query.options(contains_eager("halo_to", alias=halo_alias))
             query = query.options(contains_eager("halo_to", "timestep", alias=timestep_alias))

--- a/tests/test_property_gathering.py
+++ b/tests/test_property_gathering.py
@@ -193,9 +193,8 @@ def test_calculate_for_progenitors():
 
 def test_calculate_for_progenitors_bh():
     h = tangos.get_halo("sim/ts3/bh_1")
-    objs, = h.calculate_for_progenitors("path()")
-    assert len(objs)==3
-    print(objs)
+    objs, = h.calculate_for_progenitors("dbid()")
+    testing.assert_halolists_equal(objs, ['sim/ts3/BH_1', 'sim/ts2/BH_1', 'sim/ts1/BH_1'])
 
 def test_match_gather():
     ts1_halos, ts3_halos = tangos.get_timestep("sim/ts1").calculate_all('dbid()', 'match("sim/ts3").dbid()')

--- a/tests/test_property_gathering.py
+++ b/tests/test_property_gathering.py
@@ -191,6 +191,12 @@ def test_calculate_for_progenitors():
     assert len(objs)==3
     assert all([objs[i] == tangos.get_halo(x).id for i, x in enumerate(("sim/ts3/1", "sim/ts2/1", "sim/ts1/1"))])
 
+def test_calculate_for_progenitors_bh():
+    h = tangos.get_halo("sim/ts3/bh_1")
+    objs, = h.calculate_for_progenitors("path()")
+    assert len(objs)==3
+    print(objs)
+
 def test_match_gather():
     ts1_halos, ts3_halos = tangos.get_timestep("sim/ts1").calculate_all('dbid()', 'match("sim/ts3").dbid()')
     testing.assert_halolists_equal(ts1_halos, ['sim/ts1/1','sim/ts1/2','sim/ts1/3', 'sim/ts1/1.1'])


### PR DESCRIPTION
A bug was introduced when disambiguating `Halo`s from a new base class (`SimulationObjectBase`), whereby relation finding implicitly assumed the user was looking for halos.

This caused problems with looking over the history of black holes etc