### PR TITLE
Grep-remove runs reverse-chronologically

### DIFF
--- a/tangos/scripts/manager.py
+++ b/tangos/scripts/manager.py
@@ -372,8 +372,8 @@ def grep_remove_runs(opts):
     print(""">>> type "yes" to continue""")
 
     if input(":").lower() == "yes":
-        for r, run in enumerate(matching_runs):
-            print('Removing run ',r+1,' of ',len(matching_runs))
+        for r, run in enumerate(matching_runs[::-1]):
+            print(f'Removing run {run.id}')
             _erase_run_content(run)
         print("Done")
     else:


### PR DESCRIPTION
I've found a bug in my tool for removing tangos runs in batch since switching to mysql. I'm not 100% sure what the issue is, but I suspect it arises because the tool removes runs starting from the oldest and moving forwards chronologically, and mysql doesn't like this, from what I can gather from the traceback below. This error occurs when trying to undo a "tangos add" command, and given that the traceback mentions halolinks to other objects, it seems like mysql doesn't like removing a simulation that has links to another one, before those links are removed.

The traceback:

sqlalchemy.exc.IntegrityError: (pymysql.err.IntegrityError) (1451, 'Cannot delete or update a parent row: a foreign key constraint fails (`eagle`.`halolink`, CONSTRAINT `halolink_ibfk_1` FOREIGN KEY (`halo_from_id`) REFERENCES `halos` (`id`))')
[SQL: DELETE FROM halos WHERE %(param_1)s = halos.creator_id]
[parameters: {'param_1': 729}]
(Background on this error at: https://sqlalche.me/e/14/gkpj)

Simply reversing the list of runs to be removed appears to fix the problem. I also changed the command line output to print the specific ID of the run being removed, as this is clearer for the user (and easier to debug when issues arise!).

Of course, this only fixes this issue if one is using grep-remove to delete everything associated with a given simulation. This bug will possibly still appear if one tries to remove/rollback a "tangos add" operation in isolation without first removing the halolinks, so something more clever likely needs to be done within tangos to fix this.