### PR TITLE
Avoid locking database when importing properties in a MPI session

### DIFF
--- a/tangos/tools/property_importer.py
+++ b/tangos/tools/property_importer.py
@@ -100,8 +100,9 @@ class PropertyImporter(GenericTangosTool):
 
 
         logger.info("Add %d properties", len(rows_to_store))
-        self._session.add_all(rows_to_store)
-        self._session.commit()
+        with parallel_tasks.ExclusiveLock("add_properties"):
+            self._session.add_all(rows_to_store)
+            self._session.commit()
 
     def run_calculation_loop(self):
         base_sim = core.sim_query_from_name_list(self.options.sims)


### PR DESCRIPTION
This suggestion from @apontzen fixes #180.

Is there a good way to test for this parallel-only behaviour? I could find some tests where the `PropertyImporter` is used in an integrated way (`test_ahf_trees`, `test_stat_files`), but it does not seem like there is a dedicated test suite for its internal capabilities. 