### PR TITLE
Removing link duplicates

### DIFF
--- a/tangos/scripts/manager.py
+++ b/tangos/scripts/manager.py
@@ -172,7 +172,7 @@ def flag_duplicates_deprecated(opts):
     print("duplicate properties marked:", session.execute("update haloproperties set deprecated=1 where id in (SELECT min(id) FROM haloproperties GROUP BY halo_id, name_id HAVING COUNT(*)>1 ORDER BY halo_id, name_id)").rowcount)
 
     print("unmark all links:", session.execute("update halolink set deprecated=0").rowcount)
-    print("duplicate links marked:", session.execute("update halolink set deprecated=1 where id in (SELECT min(id) FROM halolink GROUP BY halo_from_id, halo_to_id, weight HAVING COUNT(*)>1 ORDER BY halo_from_id, halo_to_id, weight)").rowcount)
+    print("duplicate links marked:", session.execute("update halolink set deprecated=1 where id in (SELECT min(id) FROM halolink GROUP BY halo_from_id, halo_to_id, relation_id HAVING COUNT(*)>1 ORDER BY halo_from_id, halo_to_id, weight)").rowcount)
 
     session.commit()
 
@@ -213,7 +213,7 @@ def remove_duplicates(options):
             SELECT * FROM (
                 SELECT MAX(id)
                 FROM halolink
-                GROUP BY halo_from_id, halo_to_id, weight, relation_id
+                GROUP BY halo_from_id, halo_to_id, relation_id
             ) as t
         )
     """)).rowcount

--- a/tangos/scripts/manager.py
+++ b/tangos/scripts/manager.py
@@ -168,8 +168,11 @@ def flag_duplicates_deprecated(opts):
 
     session = db.core.get_default_session()
 
-    print("unmark all:",session.execute("update haloproperties set deprecated=0").rowcount)
-    print("      mark:",session.execute("update haloproperties set deprecated=1 where id in (SELECT min(id) FROM haloproperties GROUP BY halo_id, name_id HAVING COUNT(*)>1 ORDER BY halo_id, name_id)").rowcount)
+    print("unmark all properties:", session.execute("update haloproperties set deprecated=0").rowcount)
+    print("duplicate properties marked:", session.execute("update haloproperties set deprecated=1 where id in (SELECT min(id) FROM haloproperties GROUP BY halo_id, name_id HAVING COUNT(*)>1 ORDER BY halo_id, name_id)").rowcount)
+
+    print("unmark all links:", session.execute("update halolink set deprecated=0").rowcount)
+    print("duplicate links marked:", session.execute("update halolink set deprecated=1 where id in (SELECT min(id) FROM halolink GROUP BY halo_from_id, halo_to_id, weight HAVING COUNT(*)>1 ORDER BY halo_from_id, halo_to_id, weight)").rowcount)
 
     session.commit()
 
@@ -204,9 +207,21 @@ def remove_duplicates(options):
         )
     """)).rowcount
 
+    count_links = session.execute(dedent("""
+        DELETE FROM halolink
+        WHERE id NOT IN (
+            SELECT * FROM (
+                SELECT MAX(id)
+                FROM halolink
+                GROUP BY halo_from_id, halo_to_id, weight
+            ) as t
+        )
+    """)).rowcount
+
     if dialect == 'mysql':
         session.execute("SET @@SESSION.optimizer_switch = @__optimizations")
     print("Deleted %d rows" % count)
+    print("Deleted %d links" % count_links)
     session.commit()
 
 
@@ -522,10 +537,10 @@ def get_argument_parser_and_subparsers():
 
 
     subparse_deprecate = subparse.add_parser("flag-duplicates",
-                                             help="Flag old copies of properties (if they are present)")
+                                             help="Flag old copies of properties and duplicate links (if they are present)")
     subparse_deprecate.set_defaults(func=flag_duplicates_deprecated)
     subparse_deprecate = subparse.add_parser("remove-duplicates",
-                                             help="Remove old copies of properties (if they are present)")
+                                             help="Remove old copies of properties and duplicate links (if they are present)")
     subparse_deprecate.set_defaults(func=remove_duplicates)
 
     subparse_rollback = subparse.add_parser("rollback", help="Remove database updates")

--- a/tangos/scripts/manager.py
+++ b/tangos/scripts/manager.py
@@ -213,7 +213,7 @@ def remove_duplicates(options):
             SELECT * FROM (
                 SELECT MAX(id)
                 FROM halolink
-                GROUP BY halo_from_id, halo_to_id, weight
+                GROUP BY halo_from_id, halo_to_id, weight, relation_id
             ) as t
         )
     """)).rowcount

--- a/tests/test_remove_duplicate.py
+++ b/tests/test_remove_duplicate.py
@@ -1,10 +1,11 @@
+import numpy as np
+
 import tangos
 from tangos import core, testing
 from tangos.cached_writer import create_property
+from tangos.core.halo_data import link
 from tangos.scripts.manager import remove_duplicates
 from tangos.testing.simulation_generator import SimulationGeneratorForTests
-from tangos.core.halo_data import link
-import numpy as np
 
 
 def setup_module():

--- a/tests/test_remove_duplicate.py
+++ b/tests/test_remove_duplicate.py
@@ -1,14 +1,11 @@
-import numpy as np
-from tangos import testing
-from tangos.testing.simulation_generator import SimulationGeneratorForTests
-from tangos import core
-from tangos.cached_writer import create_property
 import tangos
 from tangos import core, testing
 from tangos.cached_writer import create_property
 from tangos.scripts.manager import remove_duplicates
 from tangos.testing.simulation_generator import SimulationGeneratorForTests
 from tangos.core.halo_data import link
+import numpy as np
+
 
 def setup_module():
     testing.init_blank_db_for_testing()
@@ -33,16 +30,20 @@ def setup_module():
     halo3 = tangos.get_halo(3)
     halo9 = tangos.get_halo(9)
 
-    # duplicate link between halo 1 to halo 2 with the same weight
+    # two links between halo 1 to halo 2 with the same weight and name (maximal duplicate)
     d_test = tangos.core.get_or_create_dictionary_item(session, "test")
     l_obj = link.HaloLink(halo, halo2, d_test, 1.0)
     session.add(l_obj)
     l_obj = link.HaloLink(halo, halo2, d_test, 1.0)
     session.add(l_obj)
-    # and another time, but with different weight
+    # and another time but with same weight but different name (not a duplicate)
+    diff_name = tangos.core.get_or_create_dictionary_item(session, "other_test")
+    l_obj = link.HaloLink(halo, halo2, diff_name, 1.0)
+    session.add(l_obj)
+    # and another time, with same name but different weight (conceptual duplicate but non-maximal)
     l_obj = link.HaloLink(halo, halo2, d_test, 0.5)
     session.add(l_obj)
-    # once more for halo 1 but to a different halo
+    # and another time, with same weight and name as previous but linking to a different halo (not a duplicate)
     l_obj = link.HaloLink(halo, halo3, d_test, 1.0)
     session.add(l_obj)
 
@@ -65,11 +66,11 @@ def test():
         assert halo["Mvir"] == ihalo
 
     # And three links for halo 1 and one for halo 2
-    assert tangos.get_halo(1).links.count() == 4
+    assert tangos.get_halo(1).links.count() == 5
     assert tangos.get_halo(2).links.count() == 1
-    # but only 3 links in halo 1 are unique
-    triplets = [[l.halo_from.id, l.halo_to.id, l.weight] for l in tangos.get_halo(1).all_links]
-    assert len(np.unique(triplets, axis=0)) == 3
+    # but only 4 links in halo 1 are maximally unique
+    quads = [[l.halo_from.id, l.halo_to.id, l.weight, l.relation_id] for l in tangos.get_halo(1).all_links]
+    assert len(np.unique(quads, axis=0)) == 4
 
     # Let's cleanup
     remove_duplicates(None)
@@ -82,9 +83,9 @@ def test():
         assert halo["Mvir"] == ihalo
 
     # Now halo 1 should have one less link, which are all unique
-    assert tangos.get_halo(1).links.count() == 3
-    triplets = [[l.halo_from.id, l.halo_to.id, l.weight] for l in tangos.get_halo(1).all_links]
-    assert len(np.unique(triplets, axis=0)) == 3
+    assert tangos.get_halo(1).links.count() == 4
+    quads = [[l.halo_from.id, l.halo_to.id, l.weight, l.relation_id] for l in tangos.get_halo(1).all_links]
+    assert len(np.unique(quads, axis=0)) == 4
 
     # halo 2 should not have changed
     assert tangos.get_halo(2).links.count() == 1

--- a/tests/test_remove_duplicate.py
+++ b/tests/test_remove_duplicate.py
@@ -1,3 +1,8 @@
+import numpy as np
+from tangos import testing
+from tangos.testing.simulation_generator import SimulationGeneratorForTests
+from tangos import core
+from tangos.cached_writer import create_property
 import tangos
 from tangos import core, testing
 from tangos.cached_writer import create_property
@@ -28,21 +33,20 @@ def setup_module():
     halo3 = tangos.get_halo(3)
     halo9 = tangos.get_halo(9)
 
-    # twice halo 1 to halo 2
+    # duplicate link between halo 1 to halo 2 with the same weight
     d_test = tangos.core.get_or_create_dictionary_item(session, "test")
     l_obj = link.HaloLink(halo, halo2, d_test, 1.0)
     session.add(l_obj)
-    d_test = tangos.core.get_or_create_dictionary_item(session, "test")
     l_obj = link.HaloLink(halo, halo2, d_test, 1.0)
     session.add(l_obj)
-
-    # once halo 1 to halo 3
-    d_test = tangos.core.get_or_create_dictionary_item(session, "test")
+    # and another time, but with different weight
+    l_obj = link.HaloLink(halo, halo2, d_test, 0.5)
+    session.add(l_obj)
+    # once more for halo 1 but to a different halo
     l_obj = link.HaloLink(halo, halo3, d_test, 1.0)
     session.add(l_obj)
 
-    # once halo 2 to halo 9
-    d_test = tangos.core.get_or_create_dictionary_item(session, "test")
+    # and now a completely independent link between halo 2 to halo 9
     l_obj = link.HaloLink(halo2, halo9, d_test, 1.0)
     session.add(l_obj)
 
@@ -61,8 +65,11 @@ def test():
         assert halo["Mvir"] == ihalo
 
     # And three links for halo 1 and one for halo 2
-    assert tangos.get_halo(1).links.count() == 3
+    assert tangos.get_halo(1).links.count() == 4
     assert tangos.get_halo(2).links.count() == 1
+    # but only 3 links in halo 1 are unique
+    triplets = [[l.halo_from.id, l.halo_to.id, l.weight] for l in tangos.get_halo(1).all_links]
+    assert len(np.unique(triplets, axis=0)) == 3
 
     # Let's cleanup
     remove_duplicates(None)
@@ -74,6 +81,12 @@ def test():
         halo = tangos.get_halo(ihalo)
         assert halo["Mvir"] == ihalo
 
-    # And two links for halo 1, pointing to different halos, still one for halo 2
-    assert tangos.get_halo(1).links.count() == 2
+    # Now halo 1 should have one less link, which are all unique
+    assert tangos.get_halo(1).links.count() == 3
+    triplets = [[l.halo_from.id, l.halo_to.id, l.weight] for l in tangos.get_halo(1).all_links]
+    assert len(np.unique(triplets, axis=0)) == 3
+
+    # halo 2 should not have changed
     assert tangos.get_halo(2).links.count() == 1
+    assert tangos.get_halo(2).all_links[0].halo_from.id == 2
+    assert tangos.get_halo(2).all_links[0].halo_to.id == 9

--- a/tests/test_remove_duplicate.py
+++ b/tests/test_remove_duplicate.py
@@ -41,7 +41,7 @@ def setup_module():
     diff_name = tangos.core.get_or_create_dictionary_item(session, "other_test")
     l_obj = link.HaloLink(halo, halo2, diff_name, 1.0)
     session.add(l_obj)
-    # and another time, with same name but different weight (conceptual duplicate but non-maximal)
+    # and another time, with same name but different weight (conceptual duplicate but non-maximal, does not get deleted)
     l_obj = link.HaloLink(halo, halo2, d_test, 0.5)
     session.add(l_obj)
     # and another time, with same weight and name as previous but linking to a different halo (not a duplicate)


### PR DESCRIPTION
Hi,

This a clean attempt at addressing the comments in #182, after rebasing against the `main` branch following #183 proved unnecessarily messy. 

I think the tests cover all cases described in #182. The only remaining question is whether we should attempt to delete non-maximal duplicate links, and if yes, whether the behaviour should be to keep the most recent addition to the database, or the highest weight.

