### PR TITLE
Fixing remaining ID inconsistencies in AHF handler

### DIFF
--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -526,7 +526,7 @@ class AHFInputHandler(PynbodyInputHandler):
                 elif k == "child":
                     data = [
                         proxy_object.IncompleteProxyObjectFromFinderId(ichild, 'halo')
-                        for ichild in map_child_parent[halo_i]
+                        for ichild in map_child_parent[halo.properties["halo_id"]]
                     ]
                 elif k == "shrink_center":
                     data = np.array([halo_props[k] for k in ("Xc", "Yc", "Zc")])

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -509,7 +509,7 @@ class AHFInputHandler(PynbodyInputHandler):
         h = self._construct_halo_cat(ts_extension, 'halo')
         all_IDs = [halo.properties['ID'] for halo in h]
         all_halo_ids = [halo.properties['halo_id'] for halo in h]
-        return dict(zip(IDs, halo_ids))
+        return dict(zip(all_IDs, all_halo_ids))
 
     def iterate_object_properties_for_timestep(self, ts_extension, object_typetag, property_names):
         h = self._construct_halo_cat(ts_extension, object_typetag)
@@ -531,10 +531,20 @@ class AHFInputHandler(PynbodyInputHandler):
             for k in property_names:
                 if k == "parent":
                     parent_ID = halo_props['hostHalo']
-                    data = proxy_object.IncompleteProxyObjectFromFinderId(
-                        map_ID_to_halo_id[parent_ID],
-                        'halo'
-                    )
+                    if parent_ID != -1:
+                        # If halo is not its own parent, link to parent
+                        data = proxy_object.IncompleteProxyObjectFromFinderId(
+                            map_ID_to_halo_id[parent_ID],
+                            'halo'
+                        )
+                    else:
+                        # Otherwise link to itself
+                       data = proxy_object.IncompleteProxyObjectFromFinderId(
+                            halo_props['halo_id'],
+                            'halo'
+                        )
+
+
                 elif k == "child":
                     data = [
                         proxy_object.IncompleteProxyObjectFromFinderId(ichild, 'halo')


### PR DESCRIPTION
Hi @apontzen and @cphyc,

We realised with @gandhalij that the mapping between parent haloes and child sub haloes is currently broken by the differences between AHF `ID` and `halo_id` explained in #178. 

The current implementation assumes that `hostHalo` encodes the `halo_id` of the host, whereas it really encodes its `ID`. This PR fixes this inconsistency, adding a mechanism to map `ID` and `halo_id` for the general case in which they are non-trivially related.

Comments welcome!
Martin 
