### PR TITLE
fix incorrect type assertion for BH properties

### DIFF
--- a/tangos/properties/pynbody/BH.py
+++ b/tangos/properties/pynbody/BH.py
@@ -33,7 +33,7 @@ class BH(PynbodyPropertyCalculation):
         print(self.log)
 
     def calculate(self, halo, properties):
-        if not isinstance(properties, tangos.core.halo.Halo):
+        if not isinstance(properties, tangos.core.halo.BH):
             raise RuntimeError("No proxies, please")
         boxsize = self.log.boxsize
 


### PR DESCRIPTION
In the class BH calculate method, the existing properties is checked to be a type `tangos.core.halo.Halo` when in reality it should be `tangos.core.halo.BH`