### PR TITLE
Remove hard-coded numbers of processes for multiprocessing

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Verify database
       working-directory: test_tutorial_build
       run: |
-        wget https://zenodo.org/record/8430190/files/reference_database.db?download=1 -O reference_database.db -nv
+        wget https://zenodo.org/record/10051592/files/reference_database.db?download=1 -O reference_database.db -nv
         tangos diff data.db reference_database.db --property-tolerance dm_density_profile 1e-2 0
       # --property-tolerance dm_density_profile here is because if a single particle crosses between bins
       # (which seems to happen due to differing library versions), the profile can change by this much

--- a/mpi_tests/test_mpi.py
+++ b/mpi_tests/test_mpi.py
@@ -23,4 +23,4 @@ if len(sys.argv)!=2:
     print("Syntax: test_mpi.py [backend name]")
 else:
     pt.use(sys.argv[1])
-    pt.launch(test_function, 8)
+    pt.launch(test_function)

--- a/mpi_tests/test_numpy_mpi.py
+++ b/mpi_tests/test_numpy_mpi.py
@@ -34,4 +34,4 @@ if len(sys.argv)!=2:
     print("Syntax: test_numpy_mpi.py [backend name]")
 else:
     pt.use(sys.argv[1])
-    pt.launch(test_function, 8)
+    pt.launch(test_function)

--- a/tangos/core/timestep.py
+++ b/tangos/core/timestep.py
@@ -78,7 +78,11 @@ class TimeStep(Base):
     def path(self):
         sess = Session.object_session(self)
         if sess is None:
-            return self.simulation.path+"/"+self.extension
+            from sqlalchemy import inspect
+            if 'simulation' not in inspect(self).unloaded:
+                return self.simulation.path+"/"+self.extension
+            else:
+                return '<detached>'
         else:
             with sess.no_autoflush:
                 return self.simulation.path+"/"+self.extension

--- a/tangos/parallel_tasks/__init__.py
+++ b/tangos/parallel_tasks/__init__.py
@@ -18,17 +18,6 @@ from ..log import logger
 from . import backends, jobs, message
 
 
-def _process_command_line():
-    command_line = " ".join(sys.argv)
-    match = re.match("^(.*)--backend *=? *([^ ]*)(.*)$", command_line)
-    if match is not None:
-        global _backend_name
-        _backend_name = match.group(2)
-        new_command_line = match.group(1)+" "+match.group(3)
-        sys.argv = new_command_line.split()
-
-_process_command_line()
-
 def use(name):
     global backend, _backend_name, _num_procs
     if backend is not None:
@@ -38,6 +27,16 @@ def use(name):
         _num_procs = int(num_procs)
     else:
         _backend_name = name
+
+def _process_command_line():
+    command_line = " ".join(sys.argv)
+    match = re.match("^(.*)--backend *=? *([^ ]*)(.*)$", command_line)
+    if match is not None:
+        use(match.group(2))
+        new_command_line = match.group(1)+" "+match.group(3)
+        sys.argv = new_command_line.split()
+
+_process_command_line()
 
 def init_backend():
     global backend

--- a/tangos/parallel_tasks/backends/mpi4py.py
+++ b/tangos/parallel_tasks/backends/mpi4py.py
@@ -50,10 +50,7 @@ def finalize():
     MPI.Finalize()
 
 
-def launch(function, num_procs, args):
+def launch(function, args):
     if size()==1:
         raise RuntimeError("MPI run needs minimum of 2 processors (one for manager, one for worker)")
-    if num_procs is not None:
-        if rank()==0:
-            warnings.warn("Number of processors requested (%d) will be ignored as this is an MPI run that has already selected %d processors"%(num_procs,size()))
     function(*args)

--- a/tangos/parallel_tasks/backends/multiprocessing.py
+++ b/tangos/parallel_tasks/backends/multiprocessing.py
@@ -158,8 +158,11 @@ def launch_functions(functions, args):
 
 
 
-def launch(function, num_procs, args):
-    if num_procs is None:
-        raise RuntimeError("To launch a parallel session using multiprocessing backend, you need to specify the number of processors")
+def launch(function, args):
+    from .. import _num_procs
+    if _num_procs is None:
+        raise RuntimeError("To launch a parallel session using multiprocessing backend, you need to specify the number "
+                           "of processors. You can do this by calling the backend multiprocessing-<n> where <n> is the"
+                           "number of processors you want to use.")
 
-    launch_functions([function]*num_procs, [args]*num_procs)
+    launch_functions([function]*_num_procs, [args]*_num_procs)

--- a/tangos/parallel_tasks/backends/null.py
+++ b/tangos/parallel_tasks/backends/null.py
@@ -23,7 +23,5 @@ def finalize():
     pass
 
 
-def launch(function, num_procs, args):
-    if num_procs is not None and num_procs!=1:
-        warnings.warn("Number of processors requested (%d) will be ignored as this is a single-processor run"%num_procs)
+def launch(function, args):
     function(*args)

--- a/tangos/parallel_tasks/backends/pypar.py
+++ b/tangos/parallel_tasks/backends/pypar.py
@@ -52,10 +52,7 @@ def receive_numpy_array(source):
 
 
 
-def launch(function, num_procs, args):
+def launch(function, args):
     if size()==1:
         raise RuntimeError("MPI run needs minimum of 2 processors (one for manager, one for worker)")
-    if num_procs is not None:
-        if rank()==0:
-            warnings.warn("Number of processors requested (%d) will be ignored as this is an MPI run that has already selected %d processors"%(num_procs,size()))
     function(*args)

--- a/tangos/scripts/__init__.py
+++ b/tangos/scripts/__init__.py
@@ -13,7 +13,7 @@ def add_generic_tool(subparse, class_, command, help):
     def run(options):
         obj = class_()
         obj.process_options(options)
-        parallel_tasks.launch(obj.run_calculation_loop, 2, [])
+        parallel_tasks.launch(obj.run_calculation_loop, [])
     this_subparser.set_defaults(func=run)
 
 def add_serve_tool(subparse):

--- a/tangos/scripts/add_bh.py
+++ b/tangos/scripts/add_bh.py
@@ -19,4 +19,4 @@ def main():
     The 'tangos_add_bh' command line is deprecated in favour of 'tangos import-changa-bh'.
     'tangos_add_bh' may be removed in future versions.
     """)
-    parallel_tasks.launch(run_dbwriter, 2, [sys.argv[1:]])
+    parallel_tasks.launch(run_dbwriter,  [sys.argv[1:]])

--- a/tangos/scripts/crosslink.py
+++ b/tangos/scripts/crosslink.py
@@ -20,4 +20,4 @@ def main():
     The 'tangos_crosslink' command line is deprecated in favour of 'tangos crosslink'.
     'tangos_crosslink' may be removed in future versions.
     """)
-    parallel_tasks.launch(run_dbwriter, 2, [sys.argv[1:]])
+    parallel_tasks.launch(run_dbwriter,  [sys.argv[1:]])

--- a/tangos/scripts/import_from_ahf.py
+++ b/tangos/scripts/import_from_ahf.py
@@ -9,7 +9,7 @@ def run_importer(argv):
     from tangos.tools.property_importer import PropertyImporter
     importer = PropertyImporter()
     importer.parse_command_line(argv)
-    parallel_tasks.launch(importer.run_calculation_loop, 2, [])
+    parallel_tasks.launch(importer.run_calculation_loop,  [])
 
 def main():
     print("""

--- a/tangos/scripts/manager.py
+++ b/tangos/scripts/manager.py
@@ -31,7 +31,7 @@ def _add_simulation_timesteps(options):
     adder.max_num_objects = options.max_objects
     adder.scan_simulation_and_add_all_descendants()
 def add_simulation_timesteps(options):
-    parallel_tasks.launch(_add_simulation_timesteps, 2, [options])
+    parallel_tasks.launch(_add_simulation_timesteps,  [options])
 
 
 

--- a/tangos/scripts/timelink.py
+++ b/tangos/scripts/timelink.py
@@ -19,4 +19,4 @@ def main():
     The 'tangos_timelink' command line is deprecated in favour of 'tangos link'.
     'tangos_timelink' may be removed in future versions.
     """)
-    parallel_tasks.launch(run_dbwriter, 2, [sys.argv[1:]])
+    parallel_tasks.launch(run_dbwriter,  [sys.argv[1:]])

--- a/tangos/scripts/writer.py
+++ b/tangos/scripts/writer.py
@@ -8,7 +8,7 @@ def run_dbwriter(argv):
     from tangos.tools.property_writer import PropertyWriter
     writer = PropertyWriter()
     writer.parse_command_line(argv)
-    parallel_tasks.launch(writer.run_calculation_loop, 2, [])
+    parallel_tasks.launch(writer.run_calculation_loop,  [])
 
 def main():
     print("""

--- a/tangos/tools/__init__.py
+++ b/tangos/tools/__init__.py
@@ -50,7 +50,7 @@ class GenericTangosTool(metaclass=abc.ABCMeta):
             obj = cls()
             obj.process_options(options)
             if obj.parallel:
-                parallel_tasks.launch(obj.run_calculation_loop, 2, [])
+                parallel_tasks.launch(obj.run_calculation_loop,  [])
             else:
                 obj.run_calculation_loop()
 

--- a/tangos/tools/add_simulation.py
+++ b/tangos/tools/add_simulation.py
@@ -35,6 +35,8 @@ class SimulationAdderUpdater:
     def scan_simulation_and_add_all_descendants(self):
         if self.parallel:
             assert pt.parallelism_is_active(), "Parallel backend has not been initialized"
+            from ..parallel_tasks import database
+            database.synchronize_creator_object()
             create_simulation = pt.backend.rank()==1 # nb rank 0 is busy coordinating everything
         else:
             create_simulation = True

--- a/tangos/tools/add_simulation.py
+++ b/tangos/tools/add_simulation.py
@@ -11,22 +11,25 @@ from ..log import logger
 class SimulationAdderUpdater:
     """This class contains the necessary tools to add a new simulation to the database"""
 
-    def __init__(self, simulation_output, session=None, renumber=True):
+    def __init__(self, simulation_output, renumber=True):
         """:type simulation_output tangos.simulation_outputs.HandlerBase"""
         self.simulation_output = simulation_output
 
         # if running in parallel, creating a session for the first time may trigger a race condition e.g. if the
         # database doesn't exist yet
         with pt.ExclusiveLock("creating_database"):
-            session = core.get_default_session()
+            core.get_default_session()
 
-        self.session = session
         self.min_halo_particles = config.min_halo_particles
         self.max_num_objects = config.max_num_objects
         self.renumber = renumber
 
         self.parallel = pt.parallelism_is_active()
 
+
+    @property
+    def session(self):
+        return core.get_default_session()
 
     @property
     def basename(self):

--- a/tangos/tools/crosslink.py
+++ b/tangos/tools/crosslink.py
@@ -15,8 +15,9 @@ from . import GenericTangosTool
 
 
 class GenericLinker(GenericTangosTool):
-    def __init__(self, session=None):
-        self.session = session or core.get_default_session()
+    @property
+    def session(self):
+        return core.get_default_session()
 
     def process_options(self, options):
         self.args = options

--- a/tangos/tools/property_writer.py
+++ b/tangos/tools/property_writer.py
@@ -87,7 +87,6 @@ class PropertyWriter(GenericTangosTool):
         return parser
 
     def _build_file_list(self):
-
         query = core.sim_query_from_name_list(self.options.sims)
         files = []
         if self.options.latest:
@@ -108,7 +107,14 @@ class PropertyWriter(GenericTangosTool):
             random.seed(0)
             random.shuffle(files)
 
-        self.files = files
+        self._files = files
+
+    @property
+    def files(self):
+        if not hasattr(self, '_files'):
+            self._build_file_list()
+        return self._files
+
 
     def _get_parallel_timestep_iterator(self):
         if self.options.part is not None:
@@ -145,7 +151,6 @@ class PropertyWriter(GenericTangosTool):
     def process_options(self, options):
         self.options = options
         core.process_options(self.options)
-        self._build_file_list()
         self._compile_inclusion_criterion()
 
         if self.options.load_mode=='all':

--- a/test_tutorial_build/build.sh
+++ b/test_tutorial_build/build.sh
@@ -19,7 +19,9 @@ detect_mpi() {
     export MPILOADMODE="--load-mode=server"
     echo "Detected mpirun -- will use where appropriate"
   else
-    echo "No mpirun found; running all processes in serial"
+    export MPIBACKEND="--backend=multiprocessing-3" # 1 process for server, 1 for each worker
+    export MPILOADMODE="--load-mode=server"
+    echo "No mpirun found; adopting multiprocessing with 2 workers"
   fi
 }
 

--- a/tests/test_ahf_trees.py
+++ b/tests/test_ahf_trees.py
@@ -25,7 +25,7 @@ def test_property_import():
     importer = tools.property_importer.PropertyImporter()
     importer.parse_command_line("Xc Yc Zc Mvir --for test_ahf_merger_tree".split())
     with log.LogCapturer():
-        parallel_tasks.use('multiprocessing')
+        parallel_tasks.use('multiprocessing-2')
         parallel_tasks.launch(importer.run_calculation_loop)
 
     Mvir_test, = tangos.get_timestep("test_ahf_merger_tree/tiny_000832").calculate_all("Mvir")

--- a/tests/test_ahf_trees.py
+++ b/tests/test_ahf_trees.py
@@ -26,7 +26,7 @@ def test_property_import():
     importer.parse_command_line("Xc Yc Zc Mvir --for test_ahf_merger_tree".split())
     with log.LogCapturer():
         parallel_tasks.use('multiprocessing')
-        parallel_tasks.launch(importer.run_calculation_loop,2)
+        parallel_tasks.launch(importer.run_calculation_loop)
 
     Mvir_test, = tangos.get_timestep("test_ahf_merger_tree/tiny_000832").calculate_all("Mvir")
     npt.assert_allclose(Mvir_test, [2.34068e+11,   4.94677e+10,   4.58779e+10,   4.24798e+10,   2.31297e+10,   2.1545e+10,   1.85704e+10,   1.62538e+10,   1.28763e+10])

--- a/tests/test_blocking_session.py
+++ b/tests/test_blocking_session.py
@@ -100,25 +100,27 @@ def _suppress_exception_report():
     backend._print_exceptions = True
 
 def test_non_blocking_exception():
+    pt.use("multiprocessing-3")
     if testing_db_backend != "sqlite":
         skip("This test is only relevant for sqlite databases")
 
     with _suppress_exception_report():
         with assert_raises(sqlalchemy.exc.OperationalError):
             with log.LogCapturer():
-                pt.launch(_perform_test,3, (False,))
+                pt.launch(_perform_test, (False,))
 
     db.core.get_default_session().rollback()
 
 
 
 def test_blocking_avoids_exception():
+    pt.use("multiprocessing-3")
     if testing_db_backend != "sqlite":
         skip("This test is only relevant for sqlite databases")
 
     assert tangos.get_halo("sim/ts1/6") is None
     db.core.get_default_session().commit()
     with log.LogCapturer():
-        pt.launch(_perform_test,3, (True,))
+        pt.launch(_perform_test, (True,))
 
     assert tangos.get_halo("sim/ts1/6") is not None

--- a/tests/test_blocking_session.py
+++ b/tests/test_blocking_session.py
@@ -109,7 +109,6 @@ def test_non_blocking_exception():
             with log.LogCapturer():
                 pt.launch(_perform_test, (False,))
 
-    db.core.get_default_session().rollback()
 
 
 

--- a/tests/test_consistent_trees.py
+++ b/tests/test_consistent_trees.py
@@ -54,11 +54,10 @@ def teardown_module():
 
 
 def test_property_import():
-    pt.use("multiprocessing-2")
     importer = tools.property_importer.PropertyImporter()
     importer.parse_command_line("X Y Z Mvir --for test_gadget_rockstar".split())
     with log.LogCapturer():
-        parallel_tasks.use('multiprocessing')
+        parallel_tasks.use('multiprocessing-2')
         parallel_tasks.launch(importer.run_calculation_loop)
 
     Mvir_test, = tangos.get_timestep("test_gadget_rockstar/snapshot_013").calculate_all("Mvir")

--- a/tests/test_consistent_trees.py
+++ b/tests/test_consistent_trees.py
@@ -54,11 +54,12 @@ def teardown_module():
 
 
 def test_property_import():
+    pt.use("multiprocessing-2")
     importer = tools.property_importer.PropertyImporter()
     importer.parse_command_line("X Y Z Mvir --for test_gadget_rockstar".split())
     with log.LogCapturer():
         parallel_tasks.use('multiprocessing')
-        parallel_tasks.launch(importer.run_calculation_loop,2)
+        parallel_tasks.launch(importer.run_calculation_loop)
 
     Mvir_test, = tangos.get_timestep("test_gadget_rockstar/snapshot_013").calculate_all("Mvir")
     npt.assert_allclose(Mvir_test, [1.160400e+13,   8.341900e+12,   5.061400e+12,   5.951900e+12])

--- a/tests/test_db_writer.py
+++ b/tests/test_db_writer.py
@@ -107,9 +107,9 @@ def test_basic_writing(fresh_database):
 
 
 def test_parallel_writing(fresh_database):
-    parallel_tasks.use('multiprocessing')
+    parallel_tasks.use('multiprocessing-3')
     try:
-        parallel_tasks.launch(run_writer_with_args, 3, ["dummy_property"])
+        parallel_tasks.launch(run_writer_with_args,  ["dummy_property"])
     finally:
         parallel_tasks.use('null')
     _assert_properties_as_expected()
@@ -208,9 +208,9 @@ def test_writer_handles_sim_properties(fresh_database):
     However it does not directly test that the parallel_tasks locking mechanism is called,
     which is hard. Ideally this test would therefore be completed at some point..."""
 
-    parallel_tasks.use('multiprocessing')
+    parallel_tasks.use('multiprocessing-3')
     try:
-        parallel_tasks.launch(run_writer_with_args, 3, ["dummy_property_accessing_simulation_property"])
+        parallel_tasks.launch(run_writer_with_args,  ["dummy_property_accessing_simulation_property"])
     finally:
         parallel_tasks.use('null')
 

--- a/tests/test_old_database_update.py
+++ b/tests/test_old_database_update.py
@@ -18,7 +18,8 @@ def setup_module():
 
 def teardown_module():
     tangos.core.close_db()
-    pt.launch(tangos.core.close_db, 6)
+    pt.use("multiprocessing-6")
+    pt.launch(tangos.core.close_db)
 
 def test_database_update():
     tangos.core._check_and_upgrade_database(tangos.core.get_default_engine(), 'test_add_column')

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -19,7 +19,8 @@ def setup_module():
 
 def teardown_module():
     tangos.core.close_db()
-    pt.launch(tangos.core.close_db, 6)
+    pt.use("multiprocessing-6")
+    pt.launch(tangos.core.close_db)
 
 
 def _add_property():
@@ -30,7 +31,8 @@ def _add_property():
 
 
 def test_add_property():
-    pt.launch(_add_property,3)
+    pt.use("multiprocessing-3")
+    pt.launch(_add_property)
     for i in range(1,10):
         assert tangos.get_halo(i)['my_test_property']==i
 
@@ -48,8 +50,8 @@ def _add_two_properties_different_ranges():
             tangos.core.get_default_session().commit()
 
 def test_add_two_properties_different_ranges():
-
-    pt.launch(_add_two_properties_different_ranges,3)
+    pt.use("multiprocessing-3")
+    pt.launch(_add_two_properties_different_ranges)
     for i in range(1,10):
         assert tangos.get_halo(i)['my_test_property_2']==i
         if i<8:
@@ -75,7 +77,8 @@ def test_for_loop_is_not_run_twice():
     entire task could be run twice"""
     tangos.get_halo(1)['test_count'] = 0
     tangos.get_default_session().commit()
-    pt.launch(_test_not_run_twice, 5)
+    pt.use("multiprocessing-5")
+    pt.launch(_test_not_run_twice)
     assert tangos.get_halo(1)['test_count']==3
 
 
@@ -86,7 +89,8 @@ def _test_empty_loop():
 
 
 def test_empty_loop():
-    pt.launch(_test_empty_loop,3)
+    pt.use("multiprocessing-3")
+    pt.launch(_test_empty_loop)
 
 def _test_empty_then_non_empty_loop():
     for _ in pt.distributed([]):
@@ -96,7 +100,8 @@ def _test_empty_then_non_empty_loop():
         pass
 
 def test_empty_then_non_empty_loop():
-    pt.launch(_test_empty_then_non_empty_loop, 3)
+    pt.use("multiprocessing-3")
+    pt.launch(_test_empty_then_non_empty_loop)
 
 
 def _test_synchronize_db_creator():
@@ -111,7 +116,8 @@ def _test_synchronize_db_creator():
     tangos.core.get_default_session().commit()
 
 def test_synchronize_db_creator():
-    pt.launch(_test_synchronize_db_creator,3)
+    pt.use("multiprocessing-3")
+    pt.launch(_test_synchronize_db_creator)
     assert tangos.get_halo(1)['db_creator_test_property']==1.0
     assert tangos.get_halo(2)['db_creator_test_property'] == 1.0
     creator_1, creator_2 = (tangos.get_halo(i).get_objects('db_creator_test_property')[0].creator for i in (1,2))
@@ -154,5 +160,7 @@ def _test_shared_locks_in_queue():
     pt.backend.barrier()
 
 def test_shared_locks():
-    pt.launch(_test_shared_locks,4)
-    pt.launch(_test_shared_locks_in_queue, 6)
+    pt.use("multiprocessing-4")
+    pt.launch(_test_shared_locks)
+    pt.use("multiprocessing-6")
+    pt.launch(_test_shared_locks_in_queue)

--- a/tests/test_pynbody_server.py
+++ b/tests/test_pynbody_server.py
@@ -45,7 +45,8 @@ def _get_array():
 
 
 def test_get_array():
-    pt.launch(_get_array,3)
+    pt.use("multiprocessing-3")
+    pt.launch(_get_array)
 
 
 def _test_simsnap_properties():
@@ -63,7 +64,8 @@ def _test_simsnap_properties():
 
 
 def test_simsnap_properties():
-    pt.launch(_test_simsnap_properties,2)
+    pt.use("multiprocessing-2")
+    pt.launch(_test_simsnap_properties)
 
 
 def _test_simsnap_arrays():
@@ -76,7 +78,8 @@ def _test_simsnap_arrays():
     assert (f.gas['iord'] == f_local.gas['iord']).all()
 
 def test_simsnap_arrays():
-    pt.launch(_test_simsnap_arrays,2)
+    pt.use("multiprocessing-2")
+    pt.launch(_test_simsnap_arrays)
 
 def _test_nonexistent_array():
     test_filter = pynbody.filt.Sphere('5000 kpc')
@@ -86,7 +89,8 @@ def _test_nonexistent_array():
         f['nonexistent']
 
 def test_nonexistent_array():
-    pt.launch(_test_nonexistent_array, 2)
+    pt.use("multiprocessing-2")
+    pt.launch(_test_nonexistent_array)
 
 
 def _test_halo_array():
@@ -98,7 +102,8 @@ def _test_halo_array():
     assert (f.gas['temp'] == f_local.gas['temp']).all()
 
 def test_halo_array():
-    pt.launch(_test_halo_array, 2)
+    pt.use("multiprocessing-2")
+    pt.launch(_test_halo_array)
 
 
 def _test_remote_file_index():
@@ -110,7 +115,8 @@ def _test_remote_file_index():
     assert (index_list==local_index_list).all()
 
 def test_remote_file_index():
-    pt.launch(_test_remote_file_index, 2)
+    pt.use("multiprocessing-2")
+    pt.launch(_test_remote_file_index)
 
 def _debug_print_arrays(*arrays):
     for vals in zip(*arrays):
@@ -136,7 +142,8 @@ def _test_lazy_evaluation_is_local():
     npt.assert_almost_equal(f['r'], f_local['r'], decimal=4)
 
 def test_lazy_evaluation_is_local():
-    pt.launch(_test_lazy_evaluation_is_local, 2)
+    pt.use("multiprocessing-2")
+    pt.launch(_test_lazy_evaluation_is_local)
 
 
 @pynbody.snapshot.tipsy.TipsySnap.derived_quantity
@@ -153,7 +160,8 @@ def _test_underlying_class():
     assert f.connection.underlying_pynbody_class is pynbody.snapshot.tipsy.TipsySnap
 
 def test_underlying_class():
-    pt.launch(_test_underlying_class, 2)
+    pt.use("multiprocessing-2")
+    pt.launch(_test_underlying_class)
 
 
 def _test_correct_object_loading():
@@ -168,4 +176,5 @@ def test_correct_object_loading():
     """This regression test looks for a bug where the pynbody_server module assumed halos could be
     loaded just by calling f.halos() where f was the SimSnap. This is not true in general; for example,
     for SubFind catalogues one has both halos and groups and the correct arguments must be passed."""
-    pt.launch(_test_correct_object_loading, 2)
+    pt.use("multiprocessing-2")
+    pt.launch(_test_correct_object_loading)

--- a/tests/test_simulation_adder.py
+++ b/tests/test_simulation_adder.py
@@ -136,8 +136,8 @@ def _add_with_pynbody_parallel():
     manager.scan_simulation_and_add_all_descendants()
 
 def test_add_with_pynbody_parallel(fresh_database_no_contents):
-    pt.use("multiprocessing")
-    pt.launch(_add_with_pynbody_parallel, 3)
+    pt.use("multiprocessing-3")
+    pt.launch(_add_with_pynbody_parallel)
 
     assert db.get_timestep("test_ahf_merger_tree/tiny.000640").halos.count() == 9
     assert db.get_timestep("test_ahf_merger_tree/tiny.000832").halos.count() == 9

--- a/tests/test_timestep.py
+++ b/tests/test_timestep.py
@@ -1,9 +1,23 @@
 import tangos
 from tangos import testing
 
+from sqlalchemy.orm import lazyload
+
 def setup_module():
     testing.init_blank_db_for_testing()
+
 def test_timestep_formatter():
     sim = tangos.core.Simulation('test_sim')
     ts = tangos.core.TimeStep(sim, "test_timestep")
     assert ts.path=="test_sim/test_timestep"
+
+    tangos.core.get_default_session().add_all([sim, ts])
+    tangos.core.get_default_session().commit()
+
+    ts = (tangos.core.get_default_session().
+          query(tangos.core.TimeStep).
+          options(lazyload(tangos.core.TimeStep.simulation)).first())
+
+    tangos.core.close_db()
+
+    assert ts.path=="<detached>"

--- a/tests/test_timestep.py
+++ b/tests/test_timestep.py
@@ -1,7 +1,8 @@
+from sqlalchemy.orm import lazyload
+
 import tangos
 from tangos import testing
 
-from sqlalchemy.orm import lazyload
 
 def setup_module():
     testing.init_blank_db_for_testing()


### PR DESCRIPTION
It is now possible to use as a backend `multiprocessing-<n>` where `<n>` is the number of processes to launch