### PR TITLE
Attempt to fix problem with BH creation

### DIFF
--- a/tangos/tracking.py
+++ b/tangos/tracking.py
@@ -36,7 +36,7 @@ def get_tracker_halos(ts):
     return halos, np.array(num), np.array(hid)
 
 def get_tracker_links(session, relation):
-    links = session.query(HaloLink).filter_by(relation=relation).all()
+    links = session.query(HaloLink).filter_by(relation_id=relation.id).all()
     idf = [tl.halo_from_id for tl in links]
     idt = [tl.halo_to_id for tl in links]
     return links, np.array(idf), np.array(idt)


### PR DESCRIPTION
Attempt to blindly fix issue reported by Akaxia and Nicole. It is unclear why this issue arises sometimes and not others, but they report this fixes it.

```
2024-04-29 20:44:41,505 : Gathering BH tracking information for steps <TimeStep 'h568GML.cosmo75.4096gsHsbBH/h568GML.cosmo75.4096gsHsbBH.000064' z=16.65 t=0.23 Gyr> and <TimeStep 'h568GML.cosmo75.4096gsHsbBH/h568GML.cosmo75.4096gsHsbBH.000128' z=10.40 t=0.45 Gyr>
Traceback (most recent call last):
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/engine/base.py", line 1719, in _execute_context
    context = constructor(
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/engine/default.py", line 996, in _init_compiled
    self.compiled_parameters = [
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/engine/default.py", line 997, in <listcomp>
    compiled.construct_params(
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/sql/compiler.py", line 1041, in construct_params
    pd[escaped_name] = value_param.effective_value
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/sql/elements.py", line 1599, in effective_value
    return self.callable()
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/orm/relationships.py", line 1813, in _go
    raise sa_exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: Can't resolve value for column dictionary.id on object <DictionaryItem at 0x7fefa0040070>; no value has been set for this column

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/noodle/miniconda3/bin/tangos", line 8, in <module>
    sys.exit(main())
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/tangos/scripts/__init__.py", line 51, in main
    args.func(args)
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/tangos/tools/__init__.py", line 53, in run
    parallel_tasks.launch(obj.run_calculation_loop,  [])
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/tangos/parallel_tasks/__init__.py", line 78, in launch
    result = function(*args)
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/tangos/tools/changa_bh_importer.py", line 36, in run_calculation_loop
    self._timelink_black_holes()
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/tangos/tools/changa_bh_importer.py", line 61, in _timelink_black_holes
    self._generate_halolinks(pairs)
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/tangos/tools/changa_bh_importer.py", line 81, in _generate_halolinks
    track_links_n, idf_n, idt_n = tracking.get_tracker_links(self._session, dict_obj_next)
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/tangos/tracking.py", line 35, in get_tracker_links
    links = session.query(HaloLink).filter_by(relation=relation).all()
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/orm/query.py", line 2768, in all
    return self._iter().all()
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/orm/query.py", line 2903, in _iter
    result = self.session.execute(
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/orm/session.py", line 1712, in execute
    result = conn._execute_20(statement, params or {}, execution_options)
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/engine/base.py", line 1631, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/sql/elements.py", line 332, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/engine/base.py", line 1498, in _execute_clauseelement
    ret = self._execute_context(
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/engine/base.py", line 1725, in _execute_context
    self._handle_dbapi_exception(
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/engine/base.py", line 2043, in _handle_dbapi_exception
    util.raise_(
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/util/compat.py", line 208, in raise_
    raise exception
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/engine/base.py", line 1719, in _execute_context
    context = constructor(
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/engine/default.py", line 996, in _init_compiled
    self.compiled_parameters = [
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/engine/default.py", line 997, in <listcomp>
    compiled.construct_params(
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/sql/compiler.py", line 1041, in construct_params
    pd[escaped_name] = value_param.effective_value
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/sql/elements.py", line 1599, in effective_value
    return self.callable()
  File "/Users/noodle/miniconda3/lib/python3.9/site-packages/SQLAlchemy-1.4.39-py3.9-macosx-10.9-x86_64.egg/sqlalchemy/orm/relationships.py", line 1813, in _go
    raise sa_exc.InvalidRequestError(
sqlalchemy.exc.StatementError: (sqlalchemy.exc.InvalidRequestError) Can't resolve value for column dictionary.id on object <DictionaryItem at 0x7fefa0040070>; no value has been set for this column
[SQL: SELECT halolink.id AS halolink_id, halolink.halo_from_id AS halolink_halo_from_id, halolink.halo_to_id AS halolink_halo_to_id, halolink.weight AS halolink_weight, halolink.creator_id AS halolink_creator_id, halolink.relation_id AS halolink_relation_id 
FROM halolink 
WHERE halolink.relation_id = ?]
[parameters: [{}]]
```