### PR TITLE
Add new parameters as tangos simulation properties

### DIFF
--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -705,7 +705,8 @@ class RamsesAHFInputHandler(RamsesCatalogueMixin, AHFInputHandler):
 
 class ChangaInputHandler(PynbodyInputHandler):
     flags_include = ["dPhysDenMin", "dCStar", "dTempMax",
-                     "dESN", "bLowTCool", "bSelfShield", "dExtraCoolShutoff"]
+                     "dESN", "bLowTCool", "bSelfShield", "dExtraCoolShutoff", 
+                     "dHubble0", "dOmega0", "dLambda", "dMsolUnit", "dKpcUnit", "dStarFormEfficiencyH2"]
 
     patterns = ["*.00???","*.00????","*.0????"]
 

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -705,7 +705,7 @@ class RamsesAHFInputHandler(RamsesCatalogueMixin, AHFInputHandler):
 
 class ChangaInputHandler(PynbodyInputHandler):
     flags_include = ["dPhysDenMin", "dCStar", "dTempMax",
-                     "dESN", "bLowTCool", "bSelfShield", "dExtraCoolShutoff", 
+                     "dESN", "bLowTCool", "bSelfShield", "dExtraCoolShutoff",
                      "dHubble0", "dOmega0", "dLambda", "dMsolUnit", "dKpcUnit"]
 
     patterns = ["*.00???","*.00????","*.0????"]

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -706,7 +706,7 @@ class RamsesAHFInputHandler(RamsesCatalogueMixin, AHFInputHandler):
 class ChangaInputHandler(PynbodyInputHandler):
     flags_include = ["dPhysDenMin", "dCStar", "dTempMax",
                      "dESN", "bLowTCool", "bSelfShield", "dExtraCoolShutoff", 
-                     "dHubble0", "dOmega0", "dLambda", "dMsolUnit", "dKpcUnit", "dStarFormEfficiencyH2"]
+                     "dHubble0", "dOmega0", "dLambda", "dMsolUnit", "dKpcUnit"]
 
     patterns = ["*.00???","*.00????","*.0????"]
 

--- a/tests/test_simulation_outputs.py
+++ b/tests/test_simulation_outputs.py
@@ -32,7 +32,7 @@ def test_handler_name():
 
 def test_handler_properties():
     prop = output_manager.get_properties()
-    assert len(prop) == 10
+    assert len(prop) == 15
     assert 'approx_resolution_kpc' in prop
     assert 'approx_resolution_Msol' in prop
     npt.assert_allclose(prop['approx_resolution_kpc'], 0.3499348849)


### PR DESCRIPTION
add needed parameters to the simulation object that include cosmology parameters in order to perform certain calculations as live calculations and not require loading in a snapshot. This includes Hubble0, Omega0. Lambda, dMsolUnit, dKpcUnit (the latter are for converting Hubble0 from simulation units)