### PR TITLE
feat: Support multi-level paths for custom handlers

### DIFF
--- a/tangos/input_handlers/__init__.py
+++ b/tangos/input_handlers/__init__.py
@@ -209,13 +209,22 @@ def _map_deprecated_handler_name(handler):
 def get_named_handler_class(handler):
     """Get a HandlerBase identified by the given name.
 
-    The name is of the format submodule.ClassName
+    The name is of the format submodule.ClassName or package.submodule.ClassName
 
     :rtype HandlerBase"""
     handler = _map_deprecated_handler_name(handler)
+
+    if '.' not in handler:
+        raise ValueError("Handler name must be in the format module.ClassName")
+
+    module_name, class_name = handler.rsplit('.', 1)
+
     try:
-        output_module = importlib.import_module('.'+handler.split('.')[0],__name__)
-    except ImportError:
-        output_module = importlib.import_module(handler.split('.')[0])
-    output_class = getattr(output_module, handler.split('.')[1])
+        # First, try a relative import within tangos.input_handlers
+        output_module = importlib.import_module('.' + module_name, __name__)
+    except (ImportError, ModuleNotFoundError):
+        # If that fails, try an absolute import
+        output_module = importlib.import_module(module_name)
+
+    output_class = getattr(output_module, class_name)
     return output_class

--- a/tests/test_simulation_outputs.py
+++ b/tests/test_simulation_outputs.py
@@ -26,6 +26,10 @@ def test_get_handler():
 
 def test_get_deprecated_handler():
     assert db.input_handlers.get_named_handler_class('pynbody.ChangaOutputSetHandler') == pynbody_outputs.ChangaInputHandler
+    
+def test_get_multi_level_handler():
+    assert db.input_handlers.get_named_handler_class('tangos.input_handlers.pynbody.ChangaInputHandler') == pynbody_outputs.ChangaInputHandler
+    assert db.input_handlers.get_named_handler_class('tangos.input_handlers.pynbody.ChangaOutputSetHandler') == pynbody_outputs.ChangaInputHandler
 
 def test_handler_name():
     assert pynbody_outputs.ChangaInputHandler.handler_class_name()=="pynbody.ChangaInputHandler"


### PR DESCRIPTION
This PR updates `get_named_handler_class` to correctly parse handler names with multi-level module paths, such as `package.subpackage.ClassName`.

This makes the handler loading mechanism more robust and allows for greater flexibility in organizing custom handler code.

For example, if the input is `'galyst.input_handler.ArepoHDFSubfindInputHandler'`, the `module_name` will now correctly be `'galyst.input_handler'` and the `class_name` will be `'ArepoHDFSubfindInputHandler'`.

Closes #272