### PR TITLE
Wrap particle positions after converting to physical units and before the KDTree is built

### DIFF
--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -98,6 +98,7 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
             raise NotImplementedError("Load mode %r is not implemented"%mode)
 
     def _build_kdtree(self, timestep, mode):
+        timestep.wrap() # Because we have converted pos to kpc, FP roundoff may place particles at the boundaries outside the period of the box.
         timestep.build_tree()
 
     def load_region(self, ts_extension, region_specification, mode=None, expected_number_of_queries=None) -> pynbody.snapshot.simsnap.SimSnap:

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -98,7 +98,6 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
             raise NotImplementedError("Load mode %r is not implemented"%mode)
 
     def _build_kdtree(self, timestep, mode):
-        timestep.wrap() # Because we have converted pos to kpc, FP roundoff may place particles at the boundaries outside the period of the box.
         timestep.build_tree()
 
     def load_region(self, ts_extension, region_specification, mode=None, expected_number_of_queries=None) -> pynbody.snapshot.simsnap.SimSnap:

--- a/tangos/parallel_tasks/pynbody_server/snapshot_queue.py
+++ b/tangos/parallel_tasks/pynbody_server/snapshot_queue.py
@@ -110,6 +110,7 @@ class PynbodySnapshotQueue:
                 num_threads = multiprocessing.cpu_count()
             else:
                 num_threads = None
+            self.current_snapshot.wrap() # Because we have converted pos to kpc, FP roundoff may place particles at the boundaries outside the period of the box.
             self.current_snapshot.build_tree(num_threads=num_threads,
                                              shared_mem=self.current_shared_mem_flag)
 


### PR DESCRIPTION
Converting to physical units before building the KDTree can cause spurious, roundoff-caused problems with periodic boxes.  In a snapshot where the boxsize was 1.0, and two or more particles are at -0.5 and 0.5 in code units, these same particles may fail pynbody's boundary check in `smCheckFits()`, and calculations will end up falling back to assuming no periodicity.

This small change just call's pynbody's `wrap()` before the treebuild to make sure any particles that have been shifted over the border by roundoff get re-wrapped to fit within the periodic box in physical units.