### PR TITLE
Fix issue #269 i.e. loadable_keys failure on remote snapshots

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -64,7 +64,7 @@ jobs:
         sudo apt install gcc-10 g++-10
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip "setuptools<82" wheel
         python -m pip install numpy~=${{ matrix.numpy-version}} sqlalchemy~=${{ matrix.sqlalchemy-version}}
     - name: Build and install tangos
       run: |

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Update python pip/setuptools/wheel
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip "setuptools<82" wheel
 
     - name: Build and install tangos
       run: |

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ install_requires = [
     # see https://github.com/Pylons/pyramid/issues/3731
     'numpy >= 2.0',
     'sqlalchemy >= 2.0',
-    'pyparsing >= 2.1.0',
+    'pyparsing >= 3.0.0', # PEP8 names
     'WebOb >= 1.7.0rc2', # Response.has_body
     'repoze.lru >= 0.4', # py3 compat
     'zope.interface >= 3.8.0',  # has zope.interface.registry

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 install_requires = [
-    'setuptools',
+    'setuptools<82', # this is for pyramid, which seems to require pkg_resources
+    # see https://github.com/Pylons/pyramid/issues/3731
     'numpy >= 2.0',
     'sqlalchemy >= 2.0',
     'pyparsing >= 2.1.0',

--- a/tangos/live_calculation/parser.py
+++ b/tangos/live_calculation/parser.py
@@ -21,9 +21,9 @@ def pack_args(for_function):
     return lambda t: for_function(*t)
 
 
-pp.ParserElement.enablePackrat()
+pp.ParserElement.enable_packrat()
 
-numerical_value = pp.Regex(r'-?\d+(\.\d*)?([eE]-?\d+)?').setParseAction(pack_args(FixedNumericInput))
+numerical_value = pp.Regex(r'-?\d+(\.\d*)?([eE]-?\d+)?').set_parse_action(pack_args(FixedNumericInput))
 
 IN_OPS = [("**", "power"),
           ("*", "multiply"),
@@ -93,12 +93,12 @@ live_calculation_property << property_name+parameters
 
 array_element << ((live_calculation_property | stored_property) + element_identifier)
 
-property_complete = pp.stringStart()+value_or_property_name+pp.stringEnd()
+property_complete = pp.string_start()+value_or_property_name+pp.string_end()
 
 
 def parse_property_name( name):
     with _parsing_lock:
-        return property_complete.parseString(name)[0]
+        return property_complete.parse_string(name)[0]
 
 def parse_property_name_if_required(name):
     if isinstance(name, Calculation):

--- a/tangos/parallel_tasks/pynbody_server/__init__.py
+++ b/tangos/parallel_tasks/pynbody_server/__init__.py
@@ -286,8 +286,11 @@ class RemoteSnap(pynbody.snapshot.copy_on_access.UnderlyingClassMixin, pynbody.s
 
         self._unavailable_arrays = []
 
-
-
+    def loadable_keys(self, fam=None) -> list[str]:
+        if fam is None:
+            return self._loadable_keys
+        else:
+            return self._fam_loadable_keys.get(fam, [])
 
     def _load_array(self, array_name, fam=None):
         if (array_name, fam) in self._unavailable_arrays:

--- a/tests/test_pynbody_server.py
+++ b/tests/test_pynbody_server.py
@@ -293,6 +293,16 @@ def test_loadable_keys(mode):
     assert 'pos' in f_remote.loadable_keys()
     assert 'metals' in f_remote.gas.loadable_keys()
 
+@pytest.mark.parametrize('mode', ['server', 'server-shared-mem'])
+@using_parallel_tasks
+def test_profile(mode):
+    """Direct test for issue #269 (underlying issue is tested above in test_loadable_keys)"""
+    f_remote = handler.load_object('tiny.000640', 0, 0, mode=mode)
+
+    pro = pynbody.analysis.profile.Profile(f_remote.gas)
+
+    _ = pro['metals'] # just checking there is no KeyError raised here
+
 @pytest.mark.parametrize('load_sphere', [True, False])
 @using_parallel_tasks(3)
 def test_shmem_simulation(load_sphere):

--- a/tests/test_pynbody_server.py
+++ b/tests/test_pynbody_server.py
@@ -276,14 +276,22 @@ def metals(sim):
 def test_mixed_derived_loaded_arrays(mode):
     """Sometimes an array is present on disk for some families but is derived for others. A notable real-world example
     is the mass array for gas in ramses snapshots. Previously accessing this array in a remotesnap could cause errors,
-    specifically a "derived array is not writable" error on the server. This test ensures that the correct behaviour"""
+    specifically a "derived array is not writable" error on the server. This test ensures that the correct behaviour,
+    by having a derived metals array for the dm particles"""
 
     f_remote = handler.load_object('tiny.000640', 0, 0, mode=mode)
     f_local = handler.load_object('tiny.000640', 0, 0, mode=None)
     assert (f_remote.dm['metals'] == f_local.dm['metals']).all()
     assert (f_remote.st['metals'] == f_local.st['metals']).all()
+    assert (f_remote.gas['metals'] == f_local.gas['metals']).all()
 
+@pytest.mark.parametrize('mode', ['server', 'server-shared-mem'])
+@using_parallel_tasks
+def test_loadable_keys(mode):
+    f_remote = handler.load_object('tiny.000640', 0, 0, mode=mode)
 
+    assert 'pos' in f_remote.loadable_keys()
+    assert 'metals' in f_remote.gas.loadable_keys()
 
 @pytest.mark.parametrize('load_sphere', [True, False])
 @using_parallel_tasks(3)


### PR DESCRIPTION
Because loadable_keys was not implemented correctly on remote snapshots, auto-profile creation could fail in server mode.