### PR TITLE
Allow for simulation-wide properties that are not displayed in the web server view.

### DIFF
--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -98,6 +98,7 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
             raise NotImplementedError("Load mode %r is not implemented"%mode)
 
     def _build_kdtree(self, timestep, mode):
+        timestep.wrap() # Because we have converted pos to kpc, FP roundoff may place particles at the boundaries outside the period of the box.
         timestep.build_tree()
 
     def load_region(self, ts_extension, region_specification, mode=None, expected_number_of_queries=None) -> pynbody.snapshot.simsnap.SimSnap:

--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -98,7 +98,6 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
             raise NotImplementedError("Load mode %r is not implemented"%mode)
 
     def _build_kdtree(self, timestep, mode):
-        timestep.wrap() # Because we have converted pos to kpc, FP roundoff may place particles at the boundaries outside the period of the box.
         timestep.build_tree()
 
     def load_region(self, ts_extension, region_specification, mode=None, expected_number_of_queries=None) -> pynbody.snapshot.simsnap.SimSnap:

--- a/tangos/parallel_tasks/pynbody_server/snapshot_queue.py
+++ b/tangos/parallel_tasks/pynbody_server/snapshot_queue.py
@@ -110,6 +110,7 @@ class PynbodySnapshotQueue:
                 num_threads = multiprocessing.cpu_count()
             else:
                 num_threads = None
+            self.current_snapshot.wrap() # Because we have converted pos to kpc, FP roundoff may place particles at the boundaries outside the period of the box.
             self.current_snapshot.build_tree(num_threads=num_threads,
                                              shared_mem=self.current_shared_mem_flag)
 

--- a/tangos/web/views/__init__.py
+++ b/tangos/web/views/__init__.py
@@ -27,3 +27,8 @@ def simulation_from_request(request):
     except RuntimeError:
         raise exc.HTTPNotFound()
     return sim
+
+# This method allows you to add simulation properties that will not be displayed by the web interface
+# (for example, if you want to store large metadata in your DB)
+def web_properties(properties):
+    return [q for q in properties if q.name.text[-5:] != 'noweb']

--- a/tangos/web/views/__init__.py
+++ b/tangos/web/views/__init__.py
@@ -28,7 +28,8 @@ def simulation_from_request(request):
         raise exc.HTTPNotFound()
     return sim
 
-# This method allows you to add simulation properties that will not be displayed by the web interface
-# (for example, if you want to store large metadata in your DB)
-def web_properties(properties):
+# This method allows you to add simulation properties that will not be
+# displayed by the web interface (for example, if you want to store large
+# metadata in your DB)
+def filter_properties_for_web_display(properties):
     return [q for q in properties if q.name.text[-5:] != 'noweb']

--- a/tangos/web/views/__init__.py
+++ b/tangos/web/views/__init__.py
@@ -28,8 +28,13 @@ def simulation_from_request(request):
         raise exc.HTTPNotFound()
     return sim
 
-# This method allows you to add simulation properties that will not be
-# displayed by the web interface (for example, if you want to store large
-# metadata in your DB)
 def filter_properties_for_web_display(properties):
-    return [q for q in properties if q.name.text[-5:] != 'noweb']
+    """
+    This method allows you to add simulation properties that will not be
+    displayed by the web interface (for example, if you want to store large
+    metadata in your DB).
+    """
+    def name_text(q):
+        # SimulationProperty reaches its name via .name; a DictionaryItem is the name
+        return q.name.text if hasattr(q, "name") else q.text
+    return [q for q in properties if not name_text(q).endswith("noweb")]

--- a/tangos/web/views/simulation_list.py
+++ b/tangos/web/views/simulation_list.py
@@ -6,6 +6,8 @@ from pyramid.view import view_config
 import tangos
 from tangos import core
 
+from . import web_properties
+
 
 @view_config(route_name='simulation_list', renderer='../templates/simulation_list.jinja2')
 def simulation_list(request):
@@ -13,7 +15,7 @@ def simulation_list(request):
 
     cats = session.query(core.DictionaryItem).join(core.simulation.SimulationProperty).all()
 
-    titles = ["Name"] + [z.text for z in cats]
+    titles = ["Name"] + [z.text for z in cats if z.text[-5:] != 'noweb']
     ids = [z.id for z in cats]
 
     sims = session.query(tangos.core.simulation.Simulation).all()
@@ -23,7 +25,7 @@ def simulation_list(request):
     for x in sims:
         s = [x.basename] + ["&ndash;"] * (len(titles) - 1)
 
-        for q in x.properties:
+        for q in web_properties(x.properties):
             s[1 + ids.index(q.name_id)] = q.data_repr()
 
         simulations.append(s)

--- a/tangos/web/views/simulation_list.py
+++ b/tangos/web/views/simulation_list.py
@@ -13,9 +13,9 @@ from . import filter_properties_for_web_display
 def simulation_list(request):
     session = request.dbsession
 
-    cats = session.query(core.DictionaryItem).join(core.simulation.SimulationProperty).all()
+    cats = filter_properties_for_web_display(session.query(core.DictionaryItem).join(core.simulation.SimulationProperty).all())
 
-    titles = ["Name"] + [z.text for z in cats if z.text[-5:] != 'noweb']
+    titles = ["Name"] + [z.text for z in cats]
     ids = [z.id for z in cats]
 
     sims = session.query(tangos.core.simulation.Simulation).all()

--- a/tangos/web/views/simulation_list.py
+++ b/tangos/web/views/simulation_list.py
@@ -6,7 +6,7 @@ from pyramid.view import view_config
 import tangos
 from tangos import core
 
-from . import web_properties
+from . import filter_properties_for_web_display
 
 
 @view_config(route_name='simulation_list', renderer='../templates/simulation_list.jinja2')
@@ -25,7 +25,7 @@ def simulation_list(request):
     for x in sims:
         s = [x.basename] + ["&ndash;"] * (len(titles) - 1)
 
-        for q in web_properties(x.properties):
+        for q in filter_properties_for_web_display(x.properties):
             s[1 + ids.index(q.name_id)] = q.data_repr()
 
         simulations.append(s)

--- a/tangos/web/views/simulation_view.py
+++ b/tangos/web/views/simulation_view.py
@@ -6,7 +6,7 @@ from sqlalchemy import func
 import tangos
 from tangos import core
 
-from . import simulation_from_request
+from . import simulation_from_request, web_properties
 
 
 @view_config(route_name='simulation_view', renderer='../templates/simulation_view.jinja2')
@@ -34,7 +34,7 @@ def simulation_view(request):
     simname = sim.basename
 
     props = []
-    for q in sim.properties:
+    for q in web_properties(sim.properties):
         props.append((q.name.text, q.data_repr()))
 
     return {'simulation':simname,

--- a/tangos/web/views/simulation_view.py
+++ b/tangos/web/views/simulation_view.py
@@ -6,7 +6,7 @@ from sqlalchemy import func
 import tangos
 from tangos import core
 
-from . import simulation_from_request, web_properties
+from . import simulation_from_request, filter_properties_for_web_display
 
 
 @view_config(route_name='simulation_view', renderer='../templates/simulation_view.jinja2')
@@ -34,7 +34,7 @@ def simulation_view(request):
     simname = sim.basename
 
     props = []
-    for q in web_properties(sim.properties):
+    for q in filter_properties_for_web_display(sim.properties):
         props.append((q.name.text, q.data_repr()))
 
     return {'simulation':simname,

--- a/tangos/web/views/simulation_view.py
+++ b/tangos/web/views/simulation_view.py
@@ -6,7 +6,7 @@ from sqlalchemy import func
 import tangos
 from tangos import core
 
-from . import simulation_from_request, filter_properties_for_web_display
+from . import filter_properties_for_web_display, simulation_from_request
 
 
 @view_config(route_name='simulation_view', renderer='../templates/simulation_view.jinja2')


### PR DESCRIPTION
This PR adds some code to the `tangos/web/views/` scripts that allow you to add simulation-wide properties that will not be displayed in the web server by appending 'noweb' to the end of their names.  This is useful for large metadata properties (for example, an entire copy of the param, log file, or a README) that can aid in building reproducible databases.  Without this feature, properties stored as large `ndarrays` or strings can render the web view unreadable, and pure python lists can cause the server to crash when it calls `data_repr()` on the property.  This shouldn't impact any other behaviour.