### PR TITLE
Fix for non-consecutive AHF halo IDs.

### DIFF
--- a/tangos/input_handlers/pynbody.py
+++ b/tangos/input_handlers/pynbody.py
@@ -265,7 +265,7 @@ class PynbodyInputHandler(finding.PatternBasedFileDiscovery, HandlerBase):
             h2 = self.get_catalogue(ts2, object_typetag)
 
         if halo_max is None:
-            halo_max = max(len(h2), len(h1))
+            halo_max = np.inf
 
         matches = self.create_bridge(f1, f2).fuzzy_match_halos(
             h1, h2, threshold=threshold, use_family=only_family,


### PR DESCRIPTION
AHF can produce non-consecutive/contiguous halo IDs.  This can lead to issues in cross-link when calculating the largest halo index.  This commit fixes that by just using infinite as a max.  This may also fix issue #289.