### PR TITLE
Add a lambda front-end to the live calculation system

### DIFF
--- a/docs/live_calculation.md
+++ b/docs/live_calculation.md
@@ -36,10 +36,11 @@ For most interactive and scripted work the lambda form is the more comfortable o
 It is genuine python, so your editor highlights it, matches your brackets, and complains if
 you leave one unclosed; and there is no quoting to get right.
 
-The string form remains fully supported, and is the one to reach for whenever a calculation
-has to exist as text: typed into the [web interface](data_exploration_webserver.md), read
-from a configuration file or a command line argument, or stored in a database. It is also
-the form used in most existing tangos scripts and in the tutorial notebooks.
+The lambda form is new in tangos 1.12.0. The string form has always been available, and
+remains fully supported; it is the one to reach for whenever a calculation has to exist as
+text: typed into the [web interface](data_exploration_webserver.md), read from a
+configuration file or a command line argument, or stored in a database. It is also the form
+used in most existing tangos scripts and in the tutorial notebooks.
 
 Both forms may be passed anywhere a calculation is expected — `Halo.calculate`,
 `TimeStep.calculate_all`, `Halo.calculate_for_progenitors`,
@@ -298,7 +299,8 @@ ts.calculate_all("!has_property(Mvir)")
 
 Note the spelling difference: the string form accepts either `!` or `~` for logical not,
 whereas the lambda form must use `~`, since python's `not` cannot be used (see
-[below](#what-cannot-be-written-as-a-lambda)).
+[below](#what-cannot-be-written-as-a-lambda)). The `~` spelling in a string is itself new in
+tangos 1.12.0; older versions accept only `!`.
 
 
 Histogram properties

--- a/docs/live_calculation.md
+++ b/docs/live_calculation.md
@@ -140,7 +140,7 @@ Note that _string_ inputs must have quotes when used, but property names and _ex
 * Binary operators: `*`, `/`, `+`, `-`, `**` (power)
 * Binary logic operators: `<`, `>`, `&`, `|`
 * Unary operators: `abs`, `sqrt`, `log`, `log10`
-* Unary logic operator: `!` (not)
+* Unary logic operator: `!` or, equivalently, `~` (not)
 
 **Links**
 

--- a/docs/live_calculation.md
+++ b/docs/live_calculation.md
@@ -88,7 +88,7 @@ The same calculation can be applied to every object in a timestep at once. This 
 system earns its keep:
 
 ```python
-ratio = ts.calculate_all(lambda: Mvir/Rvir)
+ratio, = ts.calculate_all(lambda: Mvir/Rvir)
 ```
 
 or along the major progenitor branch of a single halo:

--- a/docs/live_calculation.md
+++ b/docs/live_calculation.md
@@ -103,6 +103,29 @@ progenitors of a galaxy where the `SFR` property was maximum, and return its `ma
 h.calculate('find_progenitor(SFR, "max").mass')
 ```
 
+Writing calculations as python lambdas
+--------------------------------------
+
+Anywhere a calculation can be given as a string, it can equivalently be written as a python lambda taking no arguments:
+
+```python
+h.calculate(lambda: Vvir())
+h.calculate(lambda: at(Rvir/2, dm_density_profile))
+ts.calculate_all(lambda: later(5).Mvir, lambda: Mvir)
+h.calculate_for_progenitors(lambda: SFR_histogram[0])
+```
+
+Names that do not correspond to a python variable are interpreted as database properties or live-calculation functions, exactly as in the string form. Names that _do_ resolve to a python variable holding a number, a string or another calculation are substituted into the calculation, so that
+
+```python
+radius = 5.0
+h.calculate(lambda: at(radius, dm_density_profile))
+```
+
+is equivalent to `h.calculate("at(5.0,dm_density_profile)")`.
+
+Because the lambda is genuine python, python's rules apply. In particular, `!` becomes `~`; python's operator precedence applies, so comparisons combined with `&` or `|` need brackets, e.g. `lambda: (BH_mass>1e6) & (BH_central_distance<10)`; and control flow (`if`/`else`, `and`, `or`, `not`, comprehensions) cannot be used. The mini-language has no equivalent for control flow, so it is rejected with an explanation rather than silently misinterpreted. For more detail, see the documentation of the `tangos.live_calculation.from_lambda` module.
+
 General Syntax Notes
 ------------
 - a given live calculation function, `f()`, returns a value using already calculated properties of a halo

--- a/docs/live_calculation.md
+++ b/docs/live_calculation.md
@@ -409,10 +409,10 @@ database property: if it holds a number, string or calculation it will be interp
 the property of that name will not be consulted. Avoid, for example, storing a radius in a
 variable called `Rvir` and then writing `lambda: at(Rvir/2, dm_density_profile)`.
 
-Finer control over all of this is available through the `name_resolution` argument of
+Finer control over all of this is available through the `python_names` argument of
 `tangos.live_calculation.from_lambda.to_calculation`, which can force every name to be
-treated as a tangos name, or conversely make python scoping rules apply throughout; see its
-docstring for details.
+treated as a tangos name (`python_names='never'`), or conversely make python scoping rules
+apply throughout (`python_names='always'`); see its docstring for details.
 
 ### What cannot be written as a lambda
 

--- a/docs/live_calculation.md
+++ b/docs/live_calculation.md
@@ -1,14 +1,62 @@
-The live-calculation mini-language
-==================================
+The live calculation system
+===========================
 
-Halo properties that are stored in the database can be re-processed using a set of powerful tools that are designed to pull out insight into the data. Using this framework with `Timestep.calculate_all` or `Halo.calculate_for_descendants` can result in far faster evaluation than would be achieved by manually evaluating the equivalent on each individual halo.
+Tangos stores properties of objects (halos, black holes, groups, ...) in a database. Often
+what you actually want is not a stored property but something derived from one: the virial
+velocity rather than the mass and radius; the density at half the virial radius rather than
+the whole density profile; the mass of a halo's descendant five snapshots later.
 
-The language used to express these operations is python-like but _not_ actually python. The rest of this document explains the language, first through examples and then with a list of possible operations.
+You could of course loop over objects in python and work these things out one at a time. But
+that means a database query per object, and for a timestep with thousands of halos it is
+slow. The _live calculation_ system instead lets you describe the derived quantity once, and
+then evaluates it for every object of interest in a small number of queries. Using
+`TimeStep.calculate_all`, `Halo.calculate_for_progenitors` or `Halo.calculate_for_descendants`
+with a live calculation is typically far faster than the equivalent python loop.
 
-Examples
---------
+This document explains how to write live calculations, starting from simple examples and
+building up to links, histogram reassembly and the full list of built-in functions.
 
-Let's suppose you have an example timestep `ts` and halo `h`, e.g. by calling
+If you have not yet got a database to play with, see the [data exploration
+tutorial](data_exploration.md).
+
+
+Two ways to write a calculation
+-------------------------------
+
+A live calculation can be written either as a **python lambda taking no arguments**, or as a
+**string** in a small mini-language. The two are exactly equivalent — they produce the same
+calculation, and run at the same speed:
+
+```python
+h.calculate(lambda: at(Rvir/2, dm_density_profile))
+h.calculate("at(Rvir/2, dm_density_profile)")
+```
+
+For most interactive and scripted work the lambda form is the more comfortable of the two.
+It is genuine python, so your editor highlights it, matches your brackets, and complains if
+you leave one unclosed; and there is no quoting to get right.
+
+The string form remains fully supported, and is the one to reach for whenever a calculation
+has to exist as text: typed into the [web interface](data_exploration_webserver.md), read
+from a configuration file or a command line argument, or stored in a database. It is also
+the form used in most existing tangos scripts and in the tutorial notebooks.
+
+Both forms may be passed anywhere a calculation is expected — `Halo.calculate`,
+`TimeStep.calculate_all`, `Halo.calculate_for_progenitors`,
+`Halo.calculate_for_descendants` — and the two may be mixed freely in a single call:
+
+```python
+ts.calculate_all(lambda: later(5).Mvir, "Mvir")
+```
+
+The examples below give both forms side by side. Everything else in this document applies to
+both, except for the two sections at the end that describe the wrinkles specific to each.
+
+
+First steps
+-----------
+
+Suppose you have a timestep `ts` and a halo `h`:
 
 ```python
 import tangos
@@ -16,166 +64,518 @@ ts = tangos.get_timestep(...)
 h  = tangos.get_halo(...)
 ```
 
-One can gather properties that do not explicitly exist as properties within the database, but do not require a new calculation using simulation data. For example, the virial velocity, "Vvir" is calculated using only the virial mass and virial radius already calculated. However, because it doesn't exist yet as a halo property, `h['Vvir']` will return an error. Instead, you must perform a a "live-calculation" of "Vvir". `h.calculate('Vvir()')` will return the virial velocity of the halo. Since this is similar to calling a function, there are parenthesis associated with live calculated values.
+The property names used in the examples below (`Mvir`, `dm_density_profile`, `SFR_histogram`
+and so on) are illustrative; substitute whatever your own database contains, which you can
+check with `h.keys()`.
 
-Similarly, this method can be used within the `calculate_all` and `calculate_for_descendants` functions, e.g. `ts.calculate_all("Vvir()")` will reaturn the newly calculated virial velocity for all halos in the step. The same syntax would apply to `calculate_for_descendants`
+The simplest possible calculation is a single stored property. This is no more useful than
+`h['Mvir']`, but it establishes the pattern:
 
-There are some live calculations that exist which take arguments. For example, `at(r,property)` returns the value of the profile property `"property"` at radius `r`. While the second argument taken by the function *must* be an already existing halo profile property, the first argument could be either a number or even a halo property itself. Here are some examples of how one might use this function with the example profile property `"dm_density_profile"`. The values for `r` are in units of kpc.
-
-`at(5.0,dm_density_profile)` returns the dm density at 5.0 kpc
-
-`at(Rhalf_V,dm_density_profile)` returns the dm density at the V-band half light radius
-
-`at(Rvir/2,dm_density_profile)` returns the dm density at half of the virial radius of the halo
-
-
-This syntax works the same in `h.calculate` or `ts.calculate_all` or `h.calculate_for_descendants`. Note as well that it is possible to do arithmetic on your inputs (`Rvir/2`, `Rhalf_V*2`, `Rhalf_V+10`, etc would all work). Similarly, one can input operations on multiple halo properties, for example
-
-`at(5.0,ColdGasMass_encl/GasMass_encl)` returns the fraction of cold/total gas within the inner 5 kpc of a given halo.
-
-Some functions, rather than return a property, return a linked object. For example, the function `later(N)` returns a given halo's descendant halo N snapshots forward in time. The purpose of this is to connect a halo's properties at a given step to those of that halo N steps in the future (or past if you use the `earlier` function). To get properties from these links, add your target property after the function following a period. All of the above live calculation syntax also applies. For example:
-
-`ts.calculate_all('later(5).Mvir', 'Mvir')` returns the the virial mass of each halo 5 snapshots later and the current virial mass of each halo in the current step
-
-`ts.calculate_all('earlier(10).Vvir()')` returns the virial mass of each halo 10 snapshots earlier than the current step.
-
-`ts.calculate_all('earlier(2).at(Rvir/2,GasMass_encl')` returns the gas mass within half of the virial radius of each halo's main progenitor 2 snapshots previous.
-
-
-Special case use for histogram properties
------------------------------------------
-
-For *histogram* properties (currently these are just `SFR_histogram` and `BH_mdot_histogram`), the live calculation language is also the interface to special use of the stored histograms.
-
-Let's take the SFR as an example. If you have a halo `h`, and ask for `h['SFR_histogram']`, you just get a SFR histogram back as you'd expect, one bin per 20 Myr by default. However, the database is actually storing *chunks* of the star formation history and automatically recreating it for you on the *major progenitor* branch.
-
-You can instead request the SFR summed over *all* branches by typing `h.calculate("reassemble(SFR_histogram, 'sum')")`. Similarly, for a BH accretion history you could do `h.calculate("BH.reassemble(BH_mdot_histogram, 'sum')")`._
-
-If you want to manually handle the reassembly, one useful option is `h.calculate("reassemble(SFR_histogram, 'place')")`. This correctly zero-pads the histogram, but does not fill in any of the data from preceding steps, so you are free to do that yourself.
-
-Under the hood, this is implemented using the `reassemble` property of `TimeChunkedProperty` which you can find in `properties.__init__.py`. In principle it's therefore possible to implement further methods for reconstructing SFR where even more complex manipulations of the little mini-history chunks is undertaken.
-
-**Technical note**: to access the data that is actually stored in the database, as opposed to the default reconstruction, you can ask for `h.calculate("raw(SFR_histogram)")`. The default data access `h['SFR_histogram']` or `h.calculate("SFR_histogram")`_ actually expands to something equivalent to `h.calculate("reassemble(SFR_histogram")`, and the default parameter to `reassemble` is `major`, which (as previously stated) sums only over the major progenitor branch.
-
-
-Getting information on linked objects
-----------------------------------------
-
-Often halos have several linked objects associated with them. For example, any given halo may have several black holes and so
- will have several black hole objects in the database linked to it.
-Live calculations using the `link()` function will return an object linked to the halo under a given name having the maximum or minimum
-of a given quantity among all other linked objects of the same name associated with that same halo. The general syntax is as follows.
-
-```
-h.calculate('link(my_link_name, link_property, "max/min", constraint1, constraint2, ...constrantN)')
+```python
+h.calculate(lambda: Mvir)
+h.calculate("Mvir")
 ```
 
-An example would be the following, looking among black holes linked to their host halo via the "BH" link name.
+Arithmetic on stored properties works as you would expect, using `+`, `-`, `*`, `/`, `**`
+and brackets:
 
+```python
+h.calculate(lambda: Mvir/Rvir)
+h.calculate("Mvir/Rvir")
 ```
-h.calculate('link(BH,BH_mass,"max")')
+
+The same calculation can be applied to every object in a timestep at once. This is where the
+system earns its keep:
+
+```python
+ratio = ts.calculate_all(lambda: Mvir/Rvir)
 ```
 
-The above command will return an object linked under the "BH" name to halo h.
-The black hole that is returned will be the one that has the largest value of mass (based on the property called "BH_mass" of the linked black hole objects).
+or along the major progenitor branch of a single halo:
 
-It is also possible to put any arbitrary number of constraints on which link you want other than simply the maximum or minimum of some value. For example:
-
+```python
+mass_history, time = h.calculate_for_progenitors(lambda: Mvir, lambda: t())
 ```
+
+Note that `calculate_all`, `calculate_for_progenitors` and `calculate_for_descendants` take
+any number of calculations and return one array for each. Only objects for which _all_ of
+the requested calculations succeed are returned, so the arrays always line up with each other.
+
+### Live properties
+
+Some quantities are not stored in the database at all, but can be computed on demand from
+things that are. These are called _live properties_, and they are written like function
+calls. For example `t()`, `z()` and `a()` return the time, redshift and scalefactor of the
+snapshot the object belongs to:
+
+```python
+ts.calculate_all(lambda: Mvir, lambda: t())
+ts.calculate_all("Mvir", "t()")
+```
+
+The set of live properties available depends on which property modules you have installed:
+they are defined by `LivePropertyCalculation` classes, and you can write your own (see
+[writing your own properties](custom_properties.md)). A common example is a virial velocity
+calculated from the already-stored `Mvir` and `Rvir`:
+
+```python
+h.calculate(lambda: Vvir())
+h.calculate("Vvir()")
+```
+
+The brackets are what distinguishes a live property from a stored one, so `h['Vvir']` would
+fail where `h.calculate(lambda: Vvir())` succeeds. A live property works out for itself which
+stored properties it needs; you never have to tell it.
+
+Live properties can take arguments, which may be numbers, strings, stored properties, or
+whole expressions. They can also be nested inside each other. All of the following are
+legitimate:
+
+```python
+h.calculate(lambda: at(5.0, dm_density_profile))
+h.calculate(lambda: at(Rhalf_V, dm_density_profile))
+h.calculate(lambda: at(Rvir/2, dm_density_profile))
+h.calculate(lambda: at(5.0, ColdGasMass_encl/GasMass_encl))
+```
+
+
+Arrays and profiles
+-------------------
+
+Many stored properties are arrays — density profiles, mass profiles, images, histograms. The
+live calculation system can pick values out of them.
+
+A specific element is selected by indexing with an integer, which may be negative to count
+from the end:
+
+```python
+ts.calculate_all(lambda: star_mass_profile[-1])
+ts.calculate_all("star_mass_profile[-1]")
+```
+
+More usefully, `at(position, array)` interpolates the array at a given position. What
+"position" means is decided by whoever wrote the property — for a profile it is normally a
+physical radius in kpc:
+
+* `at(5.0, dm_density_profile)` is the dark matter density at 5 kpc;
+* `at(Rhalf_V, dm_density_profile)` is the density at the V-band half light radius;
+* `at(Rvir/2, dm_density_profile)` is the density at half the virial radius.
+
+The first argument may be a number or any expression, including a stored property; the second
+must be an array-valued property (possibly with arithmetic applied to it), because `at` needs
+the property's own description of what its x-axis means.
+
+`array_smooth(array, npix)` returns a Gaussian-smoothed copy of an array, and
+`max`, `min`, `posmax` and `posmin` return the maximum and minimum value of an array and the
+positions at which they occur:
+
+```python
+h.calculate(lambda: posmax(dm_density_profile))
+h.calculate("posmax(dm_density_profile)")
+```
+
+
+Links and redirection
+---------------------
+
+Objects in a tangos database are linked to each other: a halo is linked to its progenitors
+and descendants, to the black holes it hosts, to its counterpart in another simulation, and
+to anything else a property module has chosen to record.
+
+Some functions return a linked object rather than a value. To get a property of that object,
+follow it with a `.`:
+
+```python
+ts.calculate_all(lambda: later(5).Mvir, lambda: Mvir)
+ts.calculate_all("later(5).Mvir", "Mvir")
+```
+
+This returns the virial mass of each halo's descendant five snapshots later, alongside its
+present virial mass. `earlier(n)` does the same for the main progenitor `n` snapshots back,
+`latest()` and `earliest()` jump to the ends of the branch, and `match(name)` finds the
+counterpart of the object in a named simulation or timestep. Anything that can be calculated
+on an object can be calculated after a redirection, including further redirections:
+
+```python
+ts.calculate_all(lambda: earlier(10).Vvir())
+ts.calculate_all(lambda: earlier(2).at(Rvir/2, GasMass_encl))
+ts.calculate_all(lambda: match('tutorial_changa_blackholes').star_mass_profile[-1])
+```
+
+Links that a property module has written into the database are followed the same way, simply
+by naming them:
+
+```python
+h.calculate(lambda: BH_central.BH_mass)
+h.calculate("BH_central.BH_mass")
+```
+
+### Choosing between several linked objects
+
+Often an object has several links under the same name — a halo may host several black holes,
+all linked to it as `BH`. The `link()` function picks one of them out, choosing the linked
+object with the maximum or minimum of some property:
+
+```python
+h.calculate(lambda: link(BH, BH_mass, "max"))
+h.calculate('link(BH, BH_mass, "max")')
+```
+
+This returns the black hole linked to `h` under the name `BH` that has the largest `BH_mass`.
+
+Any number of further constraints may be added. Each is an expression, evaluated on the
+candidate objects, that must be true:
+
+```python
+h.calculate(lambda: link(BH, BH_mass, "max", BH_central_distance<10))
 h.calculate('link(BH, BH_mass, "max", BH_central_distance<10)')
 ```
 
-This will return the same as the first example, but this time returning the black hole
-with maximum mass among only those that are within 10 kpc of halo center. Any number of additional constraints like this can be used.
-Once you've decided how you want to pick the linked object, you can return any of that object's properties.
+This is the most massive black hole among only those within 10 kpc of the halo centre. Having
+picked the object you want, you can then ask for any of its properties:
 
-```
+```python
+h.calculate(lambda: link(BH, BH_mass, "max", BH_central_distance<10, BH_mass>1e6).BH_mdot)
 h.calculate('link(BH, BH_mass, "max", BH_central_distance<10, BH_mass>1e6).BH_mdot')
 ```
 
-This will return the accretion rate of the most massive linked black hole within halo 6 that has a mass of at least
-1e6 solar masses and is within 10 kpc of halo center.
+which gives the accretion rate of the most massive black hole that is both within 10 kpc of
+the centre and above 10<sup>6</sup> solar masses.
 
-Finally, one can also get a link to a progenitor with a particular property. For example, if you want to find the
-progenitors of a galaxy where the `SFR` property was maximum, and return its `mass` at that time, you could use:
+Note that in the lambda form, comparisons that are combined with `&` or `|` need brackets
+around them, because of python's operator precedence:
 
+```python
+h.calculate(lambda: link(BH, BH_mass, "max", (BH_mass>1e6) & (BH_central_distance<10)))
 ```
+
+### Searching along the merger tree
+
+`find_progenitor(property, "max"|"min")` searches the whole main progenitor branch for the
+step at which a property is largest or smallest, and returns the object at that step;
+`find_descendant` does the same going forwards. So to find the mass of a galaxy at the time
+its star formation rate peaked:
+
+```python
+h.calculate(lambda: find_progenitor(SFR, "max").mass)
 h.calculate('find_progenitor(SFR, "max").mass')
 ```
 
-Writing calculations as python lambdas
---------------------------------------
+### Reducing over many linked objects
 
-Anywhere a calculation can be given as a string, it can equivalently be written as a python lambda taking no arguments:
+Where `match(name)` picks a single counterpart, `match_reduce(name, calculation, reduction)`
+performs a calculation on _every_ linked object in the target simulation or timestep and then
+combines the results with `'sum'`, `'mean'`, `'min'` or `'max'`. For example, the total
+stellar mass of all counterparts of each halo in another simulation:
+
+```python
+ts.calculate_all(lambda: match_reduce('tutorial_changa', Mstar, 'sum'))
+ts.calculate_all("match_reduce('tutorial_changa', Mstar, 'sum')")
+```
+
+
+Comparisons and filters
+-----------------------
+
+Comparison operators (`>`, `<`, `>=`, `<=`, `==`, `!=`) and logical operators (`&`, `|` and
+logical not) return boolean arrays, which is what makes constraints inside `link()` work.
+They are equally useful for filtering the output of `calculate_all`, since a calculation that
+is `False` for an object is still returned — it is up to you to use it as a mask:
+
+```python
+mass, radius, is_big = ts.calculate_all(lambda: Mvir, lambda: Rvir, lambda: Mvir>1e12)
+mass = mass[is_big]
+```
+
+Two functions test whether data exists at all: `has_property(name)` is true for objects that
+have the named property stored, and `has_link(name)` is true for objects that have the named
+link. These are most useful negated:
+
+```python
+ts.calculate_all(lambda: ~has_property(Mvir))
+ts.calculate_all("!has_property(Mvir)")
+```
+
+Note the spelling difference: the string form accepts either `!` or `~` for logical not,
+whereas the lambda form must use `~`, since python's `not` cannot be used (see
+[below](#what-cannot-be-written-as-a-lambda)).
+
+
+Histogram properties
+--------------------
+
+For _histogram_ properties (currently `SFR_histogram` and `BH_mdot_histogram`), the live
+calculation system is also the interface to the way the histogram is put back together.
+
+Take the star formation rate as an example. If you have a halo `h` and ask for
+`h['SFR_histogram']`, you get an SFR history back as you would expect, one bin per 20 Myr by
+default. However, what the database actually stores is a series of *chunks* of the star
+formation history, one per timestep, which are automatically reassembled for you along the
+*major progenitor* branch.
+
+You can instead ask for the SFR summed over *all* branches:
+
+```python
+h.calculate(lambda: reassemble(SFR_histogram, 'sum'))
+h.calculate("reassemble(SFR_histogram, 'sum')")
+```
+
+and similarly for a black hole accretion history, following the link to the black hole first:
+
+```python
+h.calculate(lambda: BH.reassemble(BH_mdot_histogram, 'sum'))
+h.calculate("BH.reassemble(BH_mdot_histogram, 'sum')")
+```
+
+If you want to handle the reassembly yourself, `'place'` correctly zero-pads the histogram
+onto the full time axis but does not fill in any data from preceding steps, leaving you free
+to do that as you wish:
+
+```python
+h.calculate(lambda: reassemble(SFR_histogram, 'place'))
+```
+
+Under the hood this is implemented by the `reassemble` method of `TimeChunkedProperty`, which
+you can find in `tangos/properties/__init__.py`. It is therefore possible to implement further
+reassembly methods where more complex manipulations of the stored chunks are undertaken; see
+[understanding time-histogram properties](histogram_properties.md).
+
+**Technical note**: to get at the data exactly as stored in the database, with no
+reassembly at all, ask for `raw(SFR_histogram)`. The default data access
+`h['SFR_histogram']`, or equivalently `h.calculate(lambda: SFR_histogram)`, expands to
+something equivalent to `reassemble(SFR_histogram)`, whose default reassembly type is
+`'major'` — which, as above, sums only over the major progenitor branch.
+
+
+Writing calculations as lambdas
+-------------------------------
+
+A live calculation lambda must take no arguments, and its body is a single expression:
 
 ```python
 h.calculate(lambda: Vvir())
 h.calculate(lambda: at(Rvir/2, dm_density_profile))
-ts.calculate_all(lambda: later(5).Mvir, lambda: Mvir)
 h.calculate_for_progenitors(lambda: SFR_histogram[0])
+ts.calculate_all(lambda: later(5).Mvir, lambda: Mvir)
 ```
 
-Names that do not correspond to a python variable are interpreted as database properties or live-calculation functions, exactly as in the string form. Names that _do_ resolve to a python variable holding a number, a string or another calculation are substituted into the calculation, so that
+### How names are resolved
+
+A name inside the lambda that does not correspond to any python variable is a database
+property or a live calculation function, exactly as in the string form. This is the usual
+case: `Mvir`, `dm_density_profile`, `at` and `later` are not python variables, so they are
+interpreted as tangos names.
+
+A name that _does_ refer to a python variable holding a number, a string, or another
+calculation is substituted into the calculation. This is how you interpolate a value you have
+worked out in python:
 
 ```python
 radius = 5.0
-h.calculate(lambda: at(radius, dm_density_profile))
+h.calculate(lambda: at(radius, dm_density_profile))     # at(5.0,dm_density_profile)
 ```
 
-is equivalent to `h.calculate("at(5.0,dm_density_profile)")`.
+A python variable holding a function is used as that function. A lambda taking no arguments
+stands for a calculation in its own right, and can be written either bare or called, which
+makes it easy to build up a library of reusable pieces:
 
-Because the lambda is genuine python, python's rules apply. In particular, `!` becomes `~`; python's operator precedence applies, so comparisons combined with `&` or `|` need brackets, e.g. `lambda: (BH_mass>1e6) & (BH_central_distance<10)`; and control flow (`if`/`else`, `and`, `or`, `not`, comprehensions) cannot be used. The mini-language has no equivalent for control flow, so it is rejected with an explanation rather than silently misinterpreted. For more detail, see the documentation of the `tangos.live_calculation.from_lambda` module.
+```python
+half_radius = lambda: Rvir/2
 
-General Syntax Notes
-------------
-- a given live calculation function, `f()`, returns a value using already calculated properties of a halo
-- usage: `h.calculate('f()')`, `ts.calculate_all('f()')`, `h.calculate_for_descendants('f()')`
-- live calculations can take in arguments, including halo properties
-- `f(property)` calls the function `f`, passing the halo property `property` for each target halo. Note that no additional quotes are needed around `property`
-- `f(23)`, `f(23.0)` and `f("twenty three")` call `f` with the literal integer/float/string arguments specified. Single or double quotes can be used (`'twenty three'` and `"twenty three"` are both fine, but not `'twenty three"`)
-- In general, for any input that takes a numeric value one can use a single-value halo property instead of a number
-- All functions can implicitly access halo properties, so that (for example) `Vvir()` returns the virtual velocity without having to specify manually that it should calculate this from `Rvir` and `Vvir`
-- If a function returns a halo link (i.e. a link to another object with its own properties) `f().value` will return the `value` stored or calculated from the linked object returned by `f()`
-- Basic arithmetic works as you'd expect, so you can use `+`, `-`, `*` and `/`, as well as brackets to control precedence, e.g. `f(Mgas+Mstar)` returns the value of `f` taking the sum of the properties `Mgas` and `Mstar` for each target halo as input.
-- live calculation functions and link functions can be combined. For example, given a property function `F` and link function `L`, one can do `L(...).F(...)` where F will calculate a property given the properties from the link function results and its own inputs.
-- live calculation functions can be nested, e.g. given `f1` and `f2`, `f1(5,f2(Mvir))` will return the value of `f1` given, as its second argument, the value of `f2` with the halo property `Mvir` as input.
+h.calculate(lambda: at(half_radius, dm_density_profile))    # at(Rvir/2,dm_density_profile)
+h.calculate(lambda: at(half_radius(), dm_density_profile))  # the same
+```
 
-List of built-in mini-language functions
-----------------------------------------
+A python function taking arguments is called, with the calculations you wrote as its
+arguments, so that it can assemble part of the calculation for you:
 
-Note that _string_ inputs must have quotes when used, but property names and _expressions_ do not need quotes.
+```python
+def fractional_growth(now, before):
+    return (now - before)/now
 
+ts.calculate_all(lambda: fractional_growth(mass, earlier(2).mass))
+# equivalent to "(mass-earlier(2).mass)/mass"
+```
+
+Note that names appearing _inside_ such a function are ordinary python names, not tangos
+names — so a helper like this must take the properties it works on as arguments, rather than
+naming them itself.
+
+Python's own builtins are deliberately excluded, so that live calculation functions such as
+`abs`, `max` and `min` are not shadowed by the python functions of the same name.
+
+The one thing to watch for is a python variable that happens to share its name with a
+database property: if it holds a number, string or calculation it will be interpolated, and
+the property of that name will not be consulted. Avoid, for example, storing a radius in a
+variable called `Rvir` and then writing `lambda: at(Rvir/2, dm_density_profile)`.
+
+Finer control over all of this is available through the `name_resolution` argument of
+`tangos.live_calculation.from_lambda.to_calculation`, which can force every name to be
+treated as a tangos name, or conversely make python scoping rules apply throughout; see its
+docstring for details.
+
+### What cannot be written as a lambda
+
+The live calculation language has no control flow, and so none of python's control flow
+constructs can be used inside a lambda: `if`/`else`, `and`, `or`, `not`, `in`, `is`,
+comprehensions and generator expressions. Rather than silently mis-handling them, tangos
+rejects them with an explanation:
+
+```python
+>>> h.calculate(lambda: Mgas if Mstar else Mvir)
+ControlFlowError: the live calculation language cannot express a conditional or boolean
+short-circuit (if/else, 'and', 'or'); use '&', '|' and '~' instead
+```
+
+For element-wise logic use `&`, `|` and `~`, which do exist in the language, in place of
+`and`, `or` and `not`. Similarly, use a tuple rather than a list to request several
+calculations at once, and note that a property whose name happens to be a python keyword
+(`class`, `lambda`, ...) has to be written using the string form.
+
+
+Writing calculations as strings
+-------------------------------
+
+The string form is the original way of writing live calculations, and remains the only option
+where a calculation must be typed or stored as text — most obviously in the web interface.
+The syntax is deliberately python-like, but it is _not_ python, and there are a couple of
+places where that matters.
+
+### Quoting
+
+Property names and expressions are written bare, without quotes: `at(5.0,dm_density_profile)`,
+not `at(5.0,"dm_density_profile")`. Only genuine string arguments are quoted, using either
+single or double quotes (`'max'` and `"max"` are both fine, but not `'max"`). Because the
+calculation as a whole is a python string, it is usually easiest to write the outer quotes as
+one kind and the inner ones as the other:
+
+```python
+h.calculate('link(BH, BH_mass, "max")')
+h.calculate("reassemble(SFR_histogram, 'sum')")
+```
+
+### Operator precedence and associativity
+
+This is the one part of the string form that is likely to surprise you. The mini-language does
+_not_ use python's precedence rules. Instead, its operators bind in the following order,
+tightest first:
+
+    **   *   /   +   -   >   <   |   &   ==   !=   >=   <=
+
+and then, binding _less_ tightly than any of those, the unary operators `!`, `~` (logical not)
+and `-` (negation). Furthermore, every operator is **right**-associative. The consequences are
+worth spelling out, because they are not what a python programmer expects:
+
+| string             | means                | in python would mean |
+|--------------------|----------------------|----------------------|
+| `"a-b-c"`          | `a-(b-c)`            | `(a-b)-c`            |
+| `"a/b*c"`          | `a/(b*c)`            | `(a/b)*c`            |
+| `"a-b+c"`          | `a-(b+c)`            | `(a-b)+c`            |
+| `"-a+b"`           | `-(a+b)`             | `(-a)+b`             |
+| `"a>1 & b<2"`      | `(a>1) & (b<2)`      | `a > (1&b) < 2`      |
+
+This behaviour is long-standing and is retained so that calculations written years ago, and
+stored in databases and scripts, continue to mean what they have always meant. The practical
+advice is simply to bracket anything you are not certain about: brackets mean exactly what
+they do in python, and a fully bracketed expression reads identically in both forms.
+
+The last line of the table is the one place where the unusual precedence is convenient rather
+than surprising, since `"a>1 & b<2"` needs no brackets. In the lambda form ordinary python
+precedence applies throughout, so there the brackets are required — but nothing else about
+lambdas needs any special thought, which is the main reason to prefer them.
+
+
+General syntax notes
+--------------------
+
+These apply to both forms:
+
+* a live calculation function `f()` returns a value computed from already-stored properties
+  of an object;
+* functions can take arguments, including stored properties, expressions and other function
+  calls, e.g. `f1(5, f2(Mvir))`;
+* anywhere a number is expected, a single-valued property or an expression can be used
+  instead;
+* if a function returns a link to another object, `f().value` returns `value` from that
+  object, and link functions and property functions can be chained arbitrarily, e.g.
+  `L(...).F(...)`;
+* several calculations can be requested at once by passing several arguments to
+  `calculate_all`, `calculate_for_progenitors` or `calculate_for_descendants`; they may also
+  be grouped into a single calculation, written `(Mvir, Rvir)` in either form, which is also
+  how a group of calculations is passed to a function that expects one, e.g.
+  `f((Mvir, Rvir))`;
+* `Halo.calculate(..., return_description=True)` additionally returns the property class
+  describing the result, which is what tells you the units and the meaning of an array's
+  x-axis;
+* a calculation can also be built once and reused, either with
+  `tangos.live_calculation.parser.parse_property_name` (from a string) or
+  `tangos.live_calculation.from_lambda.to_calculation` (from a lambda); the resulting
+  `Calculation` object is accepted wherever a string or lambda is.
+
+
+List of built-in functions
+--------------------------
+
+The functions below are available in any tangos installation. Individual property modules add
+many more — anything defined as a `LivePropertyCalculation` becomes available as a function
+here, so if you are looking for something that is not in this list, check which property
+modules you have loaded and see [writing your own properties](custom_properties.md).
+
+In the string form, _string_ inputs must be quoted, while property names and expressions must
+not be. In the lambda form, ordinary python quoting applies.
 
 **Intrinsic object information**
 
-* `halo_number()`:returns halo number of target
-* `t()`: returns simulation time of target
-* `z()`: returns simulation redshift of target
-* `a()`: returns simulation scalefactor of target
-* `NDM()`: returns number of DM particles in halo
-* `NStar()`: returns number of star particles in halo
-* `Ngas()`: returns number of gas particles in halo
-* `finder_id()`: returns the halo number in the original finder output (which may differ from
-  `halo_number()`)
+* `halo_number()`: the halo number of the target object
+* `finder_id()`: the object's number in the original finder output, which may differ from
+  `halo_number()`
+* `finder_offset()`: the object's offset within the original finder output
+* `dbid()`: the object's unique database id
+* `t()`: the simulation time, in Gyr
+* `z()`: the simulation redshift
+* `a()`: the simulation scalefactor
+* `NDM()`: the number of dark matter particles
+* `NStar()`: the number of star particles
+* `NGas()`: the number of gas particles
+* `type()`, `typetag()`: the object type, as a numerical code and as a string (e.g. `halo`,
+  `BH`, `group`)
+* `path()`, `step_path()`: the full path of the object, and of the timestep containing it
 
 **Mathematics and logic**
 
-* Binary operators: `*`, `/`, `+`, `-`, `**` (power)
-* Binary logic operators: `<`, `>`, `&`, `|`
-* Unary operators: `abs`, `sqrt`, `log`, `log10`
-* Unary logic operator: `!` or, equivalently, `~` (not)
+* Arithmetic operators: `*`, `/`, `+`, `-`, `**` (power)
+* Comparison operators: `<`, `>`, `<=`, `>=`, `==`, `!=`
+* Logical operators: `&` (and), `|` (or)
+* Unary operators: `-` (negation), and logical not, written `~` in a lambda and either `!` or
+  `~` in a string
+* Functions: `abs(x)`, `sqrt(x)`, `log(x)` (natural logarithm), `log10(x)`
+
+**Testing for data**
+
+* `has_property(name)`: true where the named property is stored for the object.
+   Inputs:
+
+   - *name* (expression): the property to test for, e.g. `Mvir`
+
+* `has_link(name)`: true where the named link exists for the object.
+   Inputs:
+
+   - *name* (expression): the link to test for, e.g. `BH`
 
 **Links**
 
-*  `earlier(n)`: returns main progenitor halo n snapshots previous to current snapshot.
+*  `earlier(n)`: returns the main progenitor halo n snapshots previous to the current snapshot.
     Inputs:
 
     - *n* (integer): number of snapshots
 
-* `later(n)`: returns descendant halo n snapshots forward in time.
+* `later(n)`: returns the descendant halo n snapshots forward in time.
     Inputs:
 
     - *n* (integer): number of snapshots
+
+* `earliest()`, `latest()`: returns the earliest progenitor, or the latest descendant,
+   available in the database.
 
 * `match(s)`: returns the best match for an object in the named simulation or timestep.
    Inputs:
@@ -193,27 +593,30 @@ Note that _string_ inputs must have quotes when used, but property names and _ex
     - *constraint1*, ... (expression): an expression returning a boolean that the object must satisfy,
        e.g. `BH_mass>1e8`
 
-* `find_progenitor(property_name, property_criterion)`: Finds the progenitor which satisfies the
-   given criterion.
+* `find_progenitor(property_name, property_criterion)`, and correspondingly
+   `find_descendant`: Finds the progenitor (or descendant) which satisfies the given criterion.
    Inputs:
 
     - *property_name* (expression): the name of the property to evaluate, e.g. `SFR`.
     - *property_criterion* (string): either `'max'` or `'min'` to pick out either the progenitor with
       the maximum or minimum value of the target property
 
-* `match_reduce(s, calculation, reduction)`: finds all linked objects in a given target simulation 
+* `match_reduce(s, calculation, reduction)`: finds all linked objects in a given target simulation
   or timestep, performs a calculation on each of them, then reduces the result in a specified way.
   Inputs:
+
    - *s* (string): the name of the simulation or timestep to link to
    - *calculation* (expression): the calculation to perform on each matching object
    - *reduction* (string): either `'min'`, `'max'`, `'mean'` or `'sum'`. Specifies how to
      reduce multiple results to a single per input object.
-* Redirection operator `.`: finds a property in the linked object, e.g. `find_progenitor(SFR, 'max').mass` gets `mass`
-  at the time of maximum `SFR`.
+
+* Redirection operator `.`: finds a property in the linked object, e.g.
+  `find_progenitor(SFR, 'max').mass` gets `mass` at the time of maximum `SFR`.
 
 **Array extraction**
 
-* `array[i]`: array indexing, where `array` is an expression and `i` is an integer.
+* `array[i]`: array indexing, where `array` is an expression and `i` is an integer, which may
+  be negative to count from the end of the array.
 
 * `at(position, property_name)`: Get the value of the array at a given position.
    The meaning of the position is determined by the property implementer, but could be a physical radius
@@ -226,6 +629,11 @@ Note that _string_ inputs must have quotes when used, but property names and _ex
 
     - *property* (expression): the name of the array to operate on, e.g. `SFR_histogram`
     - *npix* (integer): the number of pixels FWHM for the Gaussian smoothing kernel
+
+* `max(property)`, `min(property)`: the maximum or minimum value of an array.
+
+* `posmax(property)`, `posmin(property)`: the position (e.g. radius) at which an array
+  reaches its maximum or minimum.
 
 **Array reassembly**
 

--- a/tangos/__init__.py
+++ b/tangos/__init__.py
@@ -11,4 +11,4 @@ from . import core, log, properties
 from .core import *
 from .query import *
 
-__version__ = '1.11.0'
+__version__ = '1.12.0'

--- a/tangos/core/halo.py
+++ b/tangos/core/halo.py
@@ -171,7 +171,8 @@ class SimulationObjectBase(Base):
 
         :param calculation: the calculation to perform, specified either as a string in
                             the mini-language, as a lambda taking no arguments
-                            (e.g. lambda: Mvir/Rvir), or as a Calculation object
+                            (e.g. lambda: Mvir/Rvir; new in tangos 1.12.0), or as a
+                            Calculation object
         :param return_description: if True, return both the value and the PropertyCalculation class describing it.
         :returns: The result of the calculation, or a tuple containing the result and the description if
                   return_description is True.
@@ -348,8 +349,8 @@ class SimulationObjectBase(Base):
         """Run the specified calculations on this halo and its descendants
 
         Each argument is a string following the syntax described in live_calculation.md,
-        or a lambda taking no arguments (e.g. lambda: Mvir/Rvir), or an instance of
-        live_calculation.Calculation.
+        or a lambda taking no arguments (e.g. lambda: Mvir/Rvir; new in tangos 1.12.0),
+        or an instance of live_calculation.Calculation.
 
         *kwargs*:
 

--- a/tangos/core/halo.py
+++ b/tangos/core/halo.py
@@ -368,7 +368,7 @@ class SimulationObjectBase(Base):
         strategy = kwargs.get('strategy', relation_finding.MultiHopMajorDescendantsStrategy)
         strategy_kwargs = kwargs.get('strategy_kwargs', {})
 
-        if isinstance(plist[0], live_calculation.Calculation):
+        if len(plist) == 1 and isinstance(plist[0], live_calculation.Calculation):
             property_description = plist[0]
         else:
             property_description = live_calculation.parser.parse_property_names(*plist)

--- a/tangos/core/halo.py
+++ b/tangos/core/halo.py
@@ -169,7 +169,9 @@ class SimulationObjectBase(Base):
         See the data exploration tutorials at https://pynbody.github.io/tangos/data_exploration.html
         for an introduction to the system.
 
-        :param calculation: the calculation (or a string representation of it to be parsed)
+        :param calculation: the calculation to perform, specified either as a string in
+                            the mini-language, as a lambda taking no arguments
+                            (e.g. lambda: Mvir/Rvir), or as a Calculation object
         :param return_description: if True, return both the value and the PropertyCalculation class describing it.
         :returns: The result of the calculation, or a tuple containing the result and the description if
                   return_description is True.
@@ -345,8 +347,9 @@ class SimulationObjectBase(Base):
     def calculate_for_descendants(self, *plist, **kwargs):
         """Run the specified calculations on this halo and its descendants
 
-        Each argument is a string (or an instance of live_calculation.Calculation), following the syntax
-        described in live_calculation.md.
+        Each argument is a string following the syntax described in live_calculation.md,
+        or a lambda taking no arguments (e.g. lambda: Mvir/Rvir), or an instance of
+        live_calculation.Calculation.
 
         *kwargs*:
 

--- a/tangos/core/timestep.py
+++ b/tangos/core/timestep.py
@@ -117,7 +117,9 @@ class TimeStep(Base):
 
         The parameters passed name the properties (or live-calculations) to return.
         For example m,r = ts.calculate_all("mass","radius") generates an array of mass and
-        radius for all objects in timestep ts.
+        radius for all objects in timestep ts. Each may equivalently be given as a lambda
+        taking no arguments, e.g. ts.calculate_all(lambda: mass, lambda: radius), or as a
+        live_calculation.Calculation object.
 
         :param object_type: integer or string representing the particular object type
                             (e.g. 'halo', 'BH' or 'group'). If None (default), all

--- a/tangos/core/timestep.py
+++ b/tangos/core/timestep.py
@@ -118,8 +118,8 @@ class TimeStep(Base):
         The parameters passed name the properties (or live-calculations) to return.
         For example m,r = ts.calculate_all("mass","radius") generates an array of mass and
         radius for all objects in timestep ts. Each may equivalently be given as a lambda
-        taking no arguments, e.g. ts.calculate_all(lambda: mass, lambda: radius), or as a
-        live_calculation.Calculation object.
+        taking no arguments, e.g. ts.calculate_all(lambda: mass, lambda: radius) (new in
+        tangos 1.12.0), or as a live_calculation.Calculation object.
 
         :param object_type: integer or string representing the particular object type
                             (e.g. 'halo', 'BH' or 'group'). If None (default), all

--- a/tangos/core/timestep.py
+++ b/tangos/core/timestep.py
@@ -148,7 +148,7 @@ class TimeStep(Base):
         if object_typetag:
             object_typecode = SimulationObjectBase.object_typecode_from_tag(object_typetag)
 
-        if isinstance(plist[0], live_calculation.Calculation):
+        if len(plist) == 1 and isinstance(plist[0], live_calculation.Calculation):
             property_description = plist[0]
         else:
             property_description = live_calculation.parser.parse_property_names(*plist)

--- a/tangos/live_calculation/__init__.py
+++ b/tangos/live_calculation/__init__.py
@@ -396,7 +396,7 @@ class MultiCalculation(Calculation):
     """Represents a single calculation that returns the results from multiple sub-calculations."""
     def __init__(self, *calculations):
         super().__init__()
-        self.calculations = [c if isinstance(c, Calculation) else parser.parse_property_name(c) for c in calculations]
+        self.calculations = [parser.parse_property_name_if_required(c) for c in calculations]
 
     def retrieves(self):
         x = set()
@@ -693,16 +693,14 @@ class Link(Calculation):
         self._multi_selection_column = None
         self._constraints_columns = []
         self._expect_multivalues = False
-        if not isinstance(self.locator, Calculation):
-            self.locator = parser.parse_property_name(self.locator)
+        self.locator = parser.parse_property_name_if_required(self.locator)
 
         if isinstance(self.locator, StoredProperty):
             self.locator.set_extraction_pattern(extraction_patterns.HaloLinkTargetGetter())
             self.locator.set_multivalued() # we want to at least know if there are multiple possible links to follow
             self._expect_multivalues = True
 
-        if not isinstance(self.property, Calculation):
-            self.property = parser.parse_property_name(self.property)
+        self.property = parser.parse_property_name_if_required(self.property)
 
 
     def __str__(self):

--- a/tangos/live_calculation/__init__.py
+++ b/tangos/live_calculation/__init__.py
@@ -71,14 +71,28 @@ def _str_operand(calculation, tighter_than):
     return str(calculation)
 
 
-def _str_atomic(calculation):
+def _str_without_operators(calculation):
     """Return a string for calculation in a context where operators cannot appear.
 
-    Brackets are not an option in such contexts (the mini-language only allows a
-    property or function to the left of a '.'), so an operator is written out in its
-    underlying function form instead, e.g. add(a,b).c rather than a+b.c
+    Brackets are not an option in such contexts (the mini-language allows only a
+    property, function or array element on either side of a '.'), so an operator is
+    written out in its underlying function form instead, e.g. add(a,b).c rather
+    than a+b.c
     """
     if calculation._operator_and_precedence() is not None:
+        return calculation._as_function_str()
+    return str(calculation)
+
+
+def _str_as_property_or_function(calculation):
+    """Return a string for calculation where only a property or function may appear.
+
+    This is more restrictive than _str_without_operators: to the left of a '.' or a
+    '[', the mini-language accepts neither operators nor array elements, so anything
+    calculated by a function is written out in function form, e.g. element(a,0).b
+    rather than a[0].b
+    """
+    if isinstance(calculation, LiveProperty):
         return calculation._as_function_str()
     return str(calculation)
 
@@ -474,7 +488,26 @@ class LiveProperty(Calculation):
         else:
             return None
 
+    def _as_element_str(self):
+        """Return the array-indexing form of this calculation, e.g. my_profile[3].
+
+        Returns None if this calculation is not an extraction of a single array
+        element, or if the index is not a literal number as the mini-language
+        requires."""
+        if self._name != "element" or len(self._inputs) != 2:
+            return None
+        array, index = self._inputs
+        if not isinstance(index, FixedNumericInput):
+            return None
+        if not isinstance(array, (StoredProperty, LiveProperty)):
+            return None
+        return _str_as_property_or_function(array) + "[" + str(index) + "]"
+
     def __str__(self):
+        as_element = self._as_element_str()
+        if as_element is not None:
+            return as_element
+
         operator = self._operator_and_precedence()
         if operator is None:
             return self._as_function_str()
@@ -673,7 +706,10 @@ class Link(Calculation):
 
 
     def __str__(self):
-        return _str_atomic(self.locator)+"."+_str_atomic(self.property)
+        # the locator is more restricted than the target: a[0].b is not valid in the
+        # mini-language, whereas a.b[0] is
+        return (_str_as_property_or_function(self.locator) + "."
+                + _str_without_operators(self.property))
 
     def name(self):
         return self.property.name()

--- a/tangos/live_calculation/__init__.py
+++ b/tangos/live_calculation/__init__.py
@@ -24,6 +24,64 @@ from tangos.util import consistent_collection
 
 from .. import core, temporary_halolist as thl
 
+#: infix operators of the mini-language, tightest-binding first, as
+#: (symbol, live-calculation function name). All are right-associative.
+IN_OPS = [("**", "power"),
+          ("*", "multiply"),
+          ("/", "divide"),
+          ("+", "add"),
+          ("-", "subtract"),
+          (">", "greater"),
+          ("<", "less"),
+          ("|", "logical_or"),
+          ("&", "logical_and"),
+          ("==", "equal"),
+          ("!=", "not_equal"),
+          (">=", "greater_equal"),
+          ("<=", "less_equal")]
+
+#: prefix operators of the mini-language. These bind less tightly than any of the
+#: infix operators, so that e.g. -a+b is negate(add(a,b)).
+UNARY_OPS = [("!", "logical_not"),
+             ("~", "logical_not"), # ~ mirrors python, so that lambdas can be used interchangeably
+             ("-", "negate")]
+
+
+def _operator_table(operators, first_precedence=0):
+    """Build a mapping from function name to (symbol, precedence) from an operator list.
+
+    Where more than one symbol maps to the same function, the first is used for
+    printing, but each keeps its own precedence, mirroring the parser.
+    """
+    table = {}
+    for precedence, (symbol, function_name) in enumerate(operators, start=first_precedence):
+        table.setdefault(function_name, (symbol, precedence))
+    return table
+
+
+_INFIX_OPERATORS = _operator_table(IN_OPS)
+_PREFIX_OPERATORS = _operator_table(UNARY_OPS, len(IN_OPS))
+
+
+def _str_operand(calculation, tighter_than):
+    """Return str(calculation) for use as an operand, bracketed if it binds too loosely"""
+    operator = calculation._operator_and_precedence()
+    if operator is not None and operator[1] > tighter_than:
+        return "(" + str(calculation) + ")"
+    return str(calculation)
+
+
+def _str_atomic(calculation):
+    """Return a string for calculation in a context where operators cannot appear.
+
+    Brackets are not an option in such contexts (the mini-language only allows a
+    property or function to the left of a '.'), so an operator is written out in its
+    underlying function form instead, e.g. add(a,b).c rather than a+b.c
+    """
+    if calculation._operator_and_precedence() is not None:
+        return calculation._as_function_str()
+    return str(calculation)
+
 
 class UnknownValue:
     """A dummy object returned by Calculation.proxy_value when the value of the calculation cannot be predicted"""
@@ -52,6 +110,13 @@ class Calculation:
 
     def __str__(self):
         raise NotImplementedError
+
+    def _operator_and_precedence(self):
+        """Return (symbol, precedence, number of operands) if this prints as an operator.
+
+        Returns None for calculations that are not written as an operator, which is
+        the case for everything except the arithmetic and logic functions."""
+        return None
 
     def set_extraction_pattern(self, extraction_pattern):
         self._extraction_pattern = extraction_pattern
@@ -396,8 +461,35 @@ class LiveProperty(Calculation):
         self._name = str(tokens[0])
         self._inputs = list(tokens[1:])
 
-    def __str__(self):
+    def _as_function_str(self):
         return self._name + "(" + (",".join(str(x) for x in self._inputs)) + ")"
+
+    def _operator_and_precedence(self):
+        if len(self._inputs) == 2 and self._name in _INFIX_OPERATORS:
+            symbol, precedence = _INFIX_OPERATORS[self._name]
+            return symbol, precedence, 2
+        elif len(self._inputs) == 1 and self._name in _PREFIX_OPERATORS:
+            symbol, precedence = _PREFIX_OPERATORS[self._name]
+            return symbol, precedence, 1
+        else:
+            return None
+
+    def __str__(self):
+        operator = self._operator_and_precedence()
+        if operator is None:
+            return self._as_function_str()
+
+        symbol, precedence, num_operands = operator
+        if num_operands == 1:
+            # prefix operators are right-associative, so an operand at the same
+            # precedence needs no brackets, e.g. --a
+            return symbol + _str_operand(self._inputs[0], precedence)
+        else:
+            # infix operators are right-associative, so the left operand must bind
+            # more tightly than this operator, whereas the right operand need only
+            # bind at least as tightly
+            return (_str_operand(self._inputs[0], precedence - 1) + symbol
+                    + _str_operand(self._inputs[1], precedence))
 
     def name(self):
         return self._name
@@ -581,7 +673,7 @@ class Link(Calculation):
 
 
     def __str__(self):
-        return str(self.locator)+"."+str(self.property)
+        return _str_atomic(self.locator)+"."+_str_atomic(self.property)
 
     def name(self):
         return self.property.name()

--- a/tangos/live_calculation/from_lambda.py
+++ b/tangos/live_calculation/from_lambda.py
@@ -66,6 +66,27 @@ A name appearing in a lambda may be intended as a tangos property (``Mvir``) or 
 be a genuine python variable that should be interpolated into the calculation
 (``lambda: at(my_radius, profile)``). The ``name_resolution`` argument to
 :func:`to_calculation` chooses between the possible policies; see its docstring.
+
+Python functions and lambdas
+----------------------------
+
+Unless ``name_resolution='tangos'`` is in force, a name that resolves to a python
+function is used as that function rather than as a live-calculation name:
+
+* a lambda taking no arguments stands for a calculation in its own right, and may be
+  written either bare or called, so that given ``half_radius = lambda: Rvir/2`` both
+  ``lambda: at(half_radius, profile)`` and ``lambda: at(half_radius(), profile)``
+  give ``at(Rvir/2,profile)``;
+
+* a function taking arguments is genuinely called while tracing, with the
+  calculations written in the lambda as its arguments, so that it can assemble part
+  of the calculation::
+
+      difference = lambda a, b: a-b
+      to_calculation(lambda: difference(MDM, Mgas))     # MDM-Mgas
+
+  The arguments must therefore match the function's signature, and names *inside*
+  the function are ordinary python names rather than live-calculation names.
 """
 
 import dis
@@ -259,6 +280,11 @@ def as_calculation(value):
     if value is None:
         raise LambdaCalculationError(
             "cannot use None in a live calculation")
+    if isinstance(value, (_PythonFunction, types.FunctionType)):
+        raise LambdaCalculationError(
+            "cannot use the python function %s as a value in a live calculation; "
+            "call it, so that its result becomes part of the calculation"
+            % _function_description(value))
     raise LambdaCalculationError(
         "cannot use %r (of type %s) in a live calculation; only numbers, strings, "
         "tuples and other calculations can be included"
@@ -271,7 +297,7 @@ def _can_be_calculation(value):
         return True
     if isinstance(value, tuple):
         return all(_can_be_calculation(v) for v in value)
-    return _is_nullary_function(value)
+    return isinstance(value, types.FunctionType)
 
 
 # --------------------------------------------------------------- symbolic stand-ins
@@ -491,6 +517,61 @@ class _Attribute(_Symbolic):
         return self._link_to(_make_element(StoredProperty(self._name), index))
 
 
+class _InlinedLambda(_Value):
+    """A stand-in for a python lambda that stands for a calculation of its own.
+
+    It can be used either as a value or called with no arguments, so that both
+    lambda: my_lambda/Mvir and lambda: my_lambda()/Mvir mean the same thing."""
+
+    __slots__ = ("_name",)
+
+    def __init__(self, name, calculation):
+        super().__init__(calculation)
+        self._name = name
+
+    def _apply_call(self, arguments):
+        if arguments:
+            raise LambdaCalculationError(
+                "the python lambda %s takes no arguments, but was called with %d"
+                % (self._name, len(arguments)))
+        return self._calculation
+
+
+class _PythonFunction:
+    """A stand-in for a python function taking arguments.
+
+    Calling it really calls the function, with the arguments being the calculations
+    written in the lambda, so that the function assembles part of the calculation."""
+
+    __slots__ = ("_name", "_function")
+
+    def __init__(self, name, function):
+        self._name = name
+        self._function = function
+
+    def __call__(self, *args, **kwargs):
+        try:
+            inspect.signature(self._function).bind(*args, **kwargs)
+        except TypeError as exception:
+            raise LambdaCalculationError(
+                "cannot call the python function %s: %s"
+                % (self._name, exception)) from None
+        return self._function(*args, **kwargs)
+
+    def __repr__(self):
+        return "<python function being traced: %s>" % self._name
+
+
+def _function_description(value):
+    """Describe a python function, for use in error messages"""
+    if isinstance(value, _PythonFunction):
+        return value._name
+    if value.__name__ == "<lambda>":
+        return "lambda at %s:%d" % (value.__code__.co_filename,
+                                    value.__code__.co_firstlineno)
+    return value.__name__
+
+
 # --------------------------------------------------------------------------- tracing
 
 NAME_RESOLUTION_MODES = ("auto", "python", "tangos")
@@ -530,7 +611,13 @@ def _substitute(name, value, name_resolution, _tracing):
     if isinstance(value, Calculation):
         return _Value(value)
     if _is_nullary_function(value):
-        return _Value(_trace(value, name_resolution, _tracing))
+        # a lambda taking no arguments is a calculation in its own right, so it is
+        # converted here and inlined wherever the name is used
+        return _InlinedLambda(name, _trace(value, name_resolution, _tracing))
+    if isinstance(value, types.FunctionType):
+        # a function taking arguments is called while tracing, so that it can
+        # assemble part of the calculation from the arguments it is given
+        return _PythonFunction(name, value)
     # anything else is passed through as its real python value, so that e.g.
     # arithmetic between python variables happens as python arithmetic
     return value

--- a/tangos/live_calculation/from_lambda.py
+++ b/tangos/live_calculation/from_lambda.py
@@ -274,6 +274,10 @@ def as_calculation(value):
         if len(value) == 0:
             raise LambdaCalculationError(
                 "cannot use an empty tuple in a live calculation")
+        if len(value) == 1:
+            # brackets around a single calculation are just grouping, matching the
+            # way the string parser reads (Mvir)
+            return as_calculation(value[0])
         return MultiCalculation(*[as_calculation(v) for v in value])
     if isinstance(value, (list, set)):
         raise LambdaCalculationError(

--- a/tangos/live_calculation/from_lambda.py
+++ b/tangos/live_calculation/from_lambda.py
@@ -482,7 +482,7 @@ class _Attribute(_Symbolic):
         return self._link_to(StoredProperty(self._name))
 
     def _description(self):
-        return "%s.%s" % (self._parent._description(), self._name)
+        return f"{self._parent._description()}.{self._name}"
 
     def _apply_call(self, arguments):
         return self._link_to(LiveProperty(self._name, *arguments))

--- a/tangos/live_calculation/from_lambda.py
+++ b/tangos/live_calculation/from_lambda.py
@@ -2,8 +2,8 @@
 
 The live-calculation mini-language is normally written as a string and turned into
 :class:`~tangos.live_calculation.Calculation` objects by
-:mod:`tangos.live_calculation.parser`. This module offers an alternative front-end
-where the calculation is written as a python lambda instead::
+:mod:`tangos.live_calculation.parser`. This module offers an alternative front-end,
+new in tangos 1.12.0, where the calculation is written as a python lambda instead::
 
     from tangos.live_calculation.from_lambda import to_calculation
 

--- a/tangos/live_calculation/from_lambda.py
+++ b/tangos/live_calculation/from_lambda.py
@@ -64,13 +64,15 @@ Name resolution
 
 A name appearing in a lambda may be intended as a tangos property (``Mvir``) or may
 be a genuine python variable that should be interpolated into the calculation
-(``lambda: at(my_radius, profile)``). The ``name_resolution`` argument to
-:func:`to_calculation` chooses between the possible policies; see its docstring.
+(``lambda: at(my_radius, profile)``). A name that does not resolve to a python
+variable is always a live-calculation name; the ``python_names`` argument to
+:func:`to_calculation` controls what happens when it does resolve. See its
+docstring for the possible policies.
 
 Python functions and lambdas
 ----------------------------
 
-Unless ``name_resolution='tangos'`` is in force, a name that resolves to a python
+Unless ``python_names='never'`` is in force, a name that resolves to a python
 function is used as that function rather than as a live-calculation name:
 
 * a lambda taking no arguments stands for a calculation in its own right, and may be
@@ -574,7 +576,7 @@ def _function_description(value):
 
 # --------------------------------------------------------------------------- tracing
 
-NAME_RESOLUTION_MODES = ("auto", "python", "tangos")
+PYTHON_NAMES_MODES = ("if_usable", "always", "never")
 
 
 def _is_nullary_function(value):
@@ -602,18 +604,18 @@ def _check_is_nullary_function(function):
             "cannot convert a generator or coroutine into a live calculation")
 
 
-def _substitute(name, value, name_resolution, _tracing):
+def _substitute(name, value, python_names, _tracing):
     """Return the object to bind to name while tracing, given its python value"""
-    if name_resolution == "tangos":
+    if python_names == "never":
         return _Name(name)
-    if name_resolution == "auto" and not _can_be_calculation(value):
+    if python_names == "if_usable" and not _can_be_calculation(value):
         return _Name(name)
     if isinstance(value, Calculation):
         return _Value(value)
     if _is_nullary_function(value):
         # a lambda taking no arguments is a calculation in its own right, so it is
         # converted here and inlined wherever the name is used
-        return _InlinedLambda(name, _trace(value, name_resolution, _tracing))
+        return _InlinedLambda(name, _trace(value, python_names, _tracing))
     if isinstance(value, types.FunctionType):
         # a function taking arguments is called while tracing, so that it can
         # assemble part of the calculation from the arguments it is given
@@ -629,20 +631,20 @@ def _global_names(code):
             if instruction.opname == "LOAD_GLOBAL"}
 
 
-def _traced_globals(function, name_resolution, _tracing):
+def _traced_globals(function, python_names, _tracing):
     # builtins are deliberately excluded: the live calculation language has functions
     # such as abs() and sum() of its own, and those should win over python's
     traced = {"__builtins__": {}}
     for name in _global_names(function.__code__):
         if name in function.__globals__:
             traced[name] = _substitute(name, function.__globals__[name],
-                                       name_resolution, _tracing)
+                                       python_names, _tracing)
         else:
             traced[name] = _Name(name)
     return traced
 
 
-def _traced_closure(function, name_resolution, _tracing):
+def _traced_closure(function, python_names, _tracing):
     if not function.__closure__:
         return None
     cells = []
@@ -653,11 +655,11 @@ def _traced_closure(function, name_resolution, _tracing):
             cells.append(cell)
             continue
         cells.append(types.CellType(
-            _substitute(name, value, name_resolution, _tracing)))
+            _substitute(name, value, python_names, _tracing)))
     return tuple(cells)
 
 
-def _trace(function, name_resolution, _tracing):
+def _trace(function, python_names, _tracing):
     _check_is_nullary_function(function)
     check_traceable(function)
 
@@ -669,10 +671,10 @@ def _trace(function, name_resolution, _tracing):
 
     shadow = types.FunctionType(
         function.__code__,
-        _traced_globals(function, name_resolution, _tracing),
+        _traced_globals(function, python_names, _tracing),
         function.__name__,
         function.__defaults__,
-        _traced_closure(function, name_resolution, _tracing))
+        _traced_closure(function, python_names, _tracing))
 
     return as_calculation(shadow())
 
@@ -691,7 +693,7 @@ def _describe(function):
     return function.__name__
 
 
-def to_calculation(function, name_resolution="auto"):
+def to_calculation(function, python_names="if_usable"):
     """Convert a lambda expression into a tangos live calculation.
 
     For example, to_calculation(lambda: later(5).Mvir/Rvir) returns the same
@@ -701,35 +703,37 @@ def to_calculation(function, name_resolution="auto"):
       appearing within it that do not resolve to python variables are interpreted as
       live-calculation property or function names.
 
-    :param name_resolution: how to treat names that *do* resolve to a python variable
+    :param python_names: how to treat names that *do* resolve to a python variable
       in the scope surrounding the lambda:
 
-      * 'auto' (default): interpolate the python value if it is something a live
-        calculation can contain (a number, a string, a tuple of those, a Calculation
-        or another lambda taking no arguments); otherwise ignore the python variable
-        and interpret the name as a live-calculation name.
-      * 'python': always use the python value. This is the closest to normal python
-        scoping rules, and allows e.g. numpy.pi to be interpolated, but a variable
-        that happens to share the name of a database property will silently shadow it.
-      * 'tangos': never use the python value; every name is a live-calculation name.
+      * 'if_usable' (default): use the python value if it is something a live
+        calculation can contain (a number, a string, a tuple of those, a Calculation,
+        or a python function or lambda); otherwise ignore the python variable and
+        interpret the name as a live-calculation name.
+      * 'always': always use the python value where the name resolves. This is the
+        closest to normal python scoping rules, and allows e.g. numpy.pi to be
+        interpolated, but a variable that happens to share the name of a database
+        property will silently shadow it.
+      * 'never': never consult the python scope; every name is a live-calculation
+        name.
 
       In all cases, python's builtins are excluded, so that live-calculation functions
       like abs() and sum() are not shadowed by the python functions of the same name.
 
     :returns: a Calculation object, equivalent to one generated by the parser
     """
-    if name_resolution not in NAME_RESOLUTION_MODES:
-        raise ValueError("name_resolution must be one of %s, not %r"
-                         % (", ".join(repr(m) for m in NAME_RESOLUTION_MODES),
-                            name_resolution))
-    return _trace(function, name_resolution, frozenset())
+    if python_names not in PYTHON_NAMES_MODES:
+        raise ValueError("python_names must be one of %s, not %r"
+                         % (", ".join(repr(m) for m in PYTHON_NAMES_MODES),
+                            python_names))
+    return _trace(function, python_names, frozenset())
 
 
-def to_calculations(*functions, name_resolution="auto"):
+def to_calculations(*functions, python_names="if_usable"):
     """Convert multiple lambda expressions into a single MultiCalculation.
 
     This is the lambda equivalent of parser.parse_property_names. See
-    :func:`to_calculation` for the meaning of name_resolution.
+    :func:`to_calculation` for the meaning of python_names.
     """
-    return MultiCalculation(*[to_calculation(f, name_resolution)
+    return MultiCalculation(*[to_calculation(f, python_names)
                               for f in functions])

--- a/tangos/live_calculation/from_lambda.py
+++ b/tangos/live_calculation/from_lambda.py
@@ -1,0 +1,648 @@
+"""Convert python lambda expressions into tangos live-calculation objects.
+
+The live-calculation mini-language is normally written as a string and turned into
+:class:`~tangos.live_calculation.Calculation` objects by
+:mod:`tangos.live_calculation.parser`. This module offers an alternative front-end
+where the calculation is written as a python lambda instead::
+
+    from tangos.live_calculation.from_lambda import to_calculation
+
+    to_calculation(lambda: Mvir)                  # StoredProperty('Mvir')
+    to_calculation(lambda: Vvir())                # LiveProperty('Vvir')
+    to_calculation(lambda: at(Rvir/2, dm_density_profile))
+    to_calculation(lambda: later(5).Mvir)         # Link(...)
+    to_calculation(lambda: (Mvir, Rvir))          # MultiCalculation(...)
+
+Anything that can be written as a string for the parser can be written as a lambda,
+with the following spellings:
+
+===========================  ====================================
+mini-language                lambda
+===========================  ====================================
+``Mvir``                     ``lambda: Mvir``
+``Vvir()``                   ``lambda: Vvir()``
+``BH.BH_mass``               ``lambda: BH.BH_mass``
+``dm_density_profile[3]``    ``lambda: dm_density_profile[3]``
+``reassemble(h, 'sum')``     ``lambda: reassemble(h, 'sum')``
+``(Mvir, Rvir)``             ``lambda: (Mvir, Rvir)``
+``~has_property(Mvir)``      ``lambda: ~has_property(Mvir)``
+``a<10 & b>5``               ``lambda: (a<10) & (b>5)``
+===========================  ====================================
+
+Note that logical_not must be spelled ``~`` rather than the mini-language's
+alternative ``!`` or python's ``not`` (which cannot be captured, see below), and that
+python's operator precedence applies rather than the mini-language's, so comparisons
+combined with ``&`` or ``|`` need explicit brackets.
+
+There are a few further differences from the string parser, all of them a consequence
+of the lambda being genuine python:
+
+* python's associativity applies, so ``lambda: a-b-c`` is ``(a-b)-c`` where the string
+  ``"a-b-c"`` is ``a-(b-c)``;
+* python folds constant sub-expressions before we see them, so ``lambda: f(2+3)``
+  arrives as ``f(5)`` and ``lambda: f(-1.5)`` as a negative literal rather than
+  ``negate(1.5)``;
+* a property whose name happens to be a python keyword cannot be written as a lambda;
+  use the string parser for those.
+
+How it works
+------------
+
+A lambda stores names plus a rule for looking them up, not values. So the lambda is
+cloned with its globals (and closure cells) replaced by symbolic stand-ins, and then
+simply called; the operators on those stand-ins build ``Calculation`` objects instead
+of computing anything. This is the same idea as sympy's ``Symbol`` or jax tracing.
+
+The consequence is that anything python evaluates eagerly cannot be seen by the
+tracer. Control flow (``if``/``else``, ``and``, ``or``, ``not``, ``in``, ``is``,
+comprehensions, generator expressions) is therefore rejected, both statically by
+inspecting the bytecode and dynamically as a backstop. The live-calculation language
+has no control flow anyway; use ``&``, ``|`` and ``~`` for element-wise logic.
+
+Name resolution
+---------------
+
+A name appearing in a lambda may be intended as a tangos property (``Mvir``) or may
+be a genuine python variable that should be interpolated into the calculation
+(``lambda: at(my_radius, profile)``). The ``name_resolution`` argument to
+:func:`to_calculation` chooses between the possible policies; see its docstring.
+"""
+
+import dis
+import inspect
+import math
+import numbers
+import re
+import types
+
+from . import (
+    Calculation,
+    FixedInput,
+    FixedNumericInput,
+    Link,
+    LiveProperty,
+    MultiCalculation,
+    StoredProperty,
+)
+
+__all__ = ["to_calculation", "to_calculations", "LambdaCalculationError",
+           "ControlFlowError"]
+
+
+class LambdaCalculationError(ValueError):
+    """Raised when a lambda cannot be expressed as a tangos live calculation"""
+
+
+class ControlFlowError(LambdaCalculationError):
+    """Raised when a lambda contains control flow, which tracing cannot capture"""
+
+
+#: valid property/function names, mirroring parser.property_name
+_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+
+#: python operator -> live-calculation function name, mirroring parser.IN_OPS
+_BINARY_OPS = {
+    "add": "add",
+    "sub": "subtract",
+    "mul": "multiply",
+    "truediv": "divide",
+    "pow": "power",
+    "and": "logical_and",
+    "or": "logical_or",
+}
+
+#: python comparison -> live-calculation function name. Comparisons need no reflected
+#: version; python swaps the operands and calls the mirrored comparison for us.
+_COMPARISON_OPS = {
+    "gt": "greater",
+    "lt": "less",
+    "ge": "greater_equal",
+    "le": "less_equal",
+    "eq": "equal",
+    "ne": "not_equal",
+}
+
+#: python unary operator -> live-calculation function name, mirroring parser.UNARY_OPS
+_UNARY_OPS = {
+    "neg": "negate",
+    "invert": "logical_not",
+    "abs": "abs",
+}
+
+#: python operators with no live-calculation equivalent -> suggested alternative
+_UNSUPPORTED_OPS = {
+    "floordiv": ("//", "use / and, if required, a live-calculation function to round"),
+    "mod": ("%", None),
+    "xor": ("^", "use & and | for logical operations"),
+    "lshift": ("<<", None),
+    "rshift": (">>", None),
+    "matmul": ("@", None),
+    "pos": ("unary +", None),
+}
+
+
+# ------------------------------------------------------------ static bytecode checks
+
+#: opcode name -> description of the construct that emits it
+_BANNED_OPS = {
+    "GET_ITER": "iteration (a comprehension, generator expression or unpacking)",
+    "FOR_ITER": "iteration (a comprehension or generator expression)",
+    "GET_AITER": "asynchronous iteration",
+    "GET_ANEXT": "asynchronous iteration",
+    "END_ASYNC_FOR": "asynchronous iteration",
+    "GET_AWAITABLE": "'await'",
+    "YIELD_VALUE": "a generator expression",
+    "SEND": "a generator expression",
+    "RETURN_GENERATOR": "a generator expression",
+    "UNPACK_SEQUENCE": "sequence unpacking",
+    "CONTAINS_OP": "an 'in' test (python coerces its result to a bool)",
+    "IS_OP": "an 'is' test (python coerces its result to a bool)",
+    "UNARY_NOT": "'not' (python coerces its result to a bool); use '~x' instead",
+    "TO_BOOL": "a conversion to bool; use '&', '|' and '~' rather than 'and', 'or' and 'not'",
+    "CALL_FUNCTION_EX": "argument unpacking with '*' or '**'",
+}
+
+_JUMP_OPS = frozenset(getattr(dis, "hasjump", None)
+                      or (set(dis.hasjrel) | set(dis.hasjabs)))
+
+_JUMP_DESCRIPTION = ("a conditional or boolean short-circuit "
+                     "(if/else, 'and', 'or'); use '&', '|' and '~' instead")
+
+
+def _source_context(code, positions):
+    """Best-effort source line, with a caret, for inclusion in an error message"""
+    lineno = getattr(positions, "lineno", None)
+    if lineno is None:
+        return ""
+    try:
+        lines, start = inspect.getsourcelines(code)
+    except (OSError, TypeError):
+        return f" (line {lineno})"
+    index = lineno - (start or 1)
+    if not 0 <= index < len(lines):
+        return f" (line {lineno})"
+    text = lines[index].rstrip("\n")
+    caret = ""
+    if (positions.col_offset is not None
+            and positions.end_lineno == positions.lineno):
+        end = positions.end_col_offset or positions.col_offset + 1
+        caret = "\n    " + " " * positions.col_offset \
+                + "^" * max(1, end - positions.col_offset)
+    return f"\n    {text.strip() if not caret else text}{caret}"
+
+
+def _walk_code(code):
+    """Yield this code object and every code object nested within its constants"""
+    yield code
+    for const in code.co_consts:
+        if isinstance(const, types.CodeType):
+            yield from _walk_code(const)
+
+
+def check_traceable(function):
+    """Raise ControlFlowError if the bytecode of function contains untraceable constructs.
+
+    This check is static, so it fires regardless of which branch would actually be
+    taken when the lambda is traced.
+    """
+    for code in _walk_code(function.__code__):
+        for instruction in dis.get_instructions(code):
+            if instruction.opname in _BANNED_OPS:
+                reason = _BANNED_OPS[instruction.opname]
+            elif instruction.opcode in _JUMP_OPS:
+                reason = _JUMP_DESCRIPTION
+            else:
+                continue
+            raise ControlFlowError(
+                "the live calculation language cannot express %s%s"
+                % (reason, _source_context(code, instruction.positions)))
+
+
+# ------------------------------------------------------- python values -> Calculation
+
+def _numeric_calculation(value):
+    """Build a FixedNumericInput from a python number.
+
+    FixedNumericInput expects the string token seen by the parser, so the value is
+    rendered back into the form the parser would have received.
+    """
+    if isinstance(value, bool):
+        return FixedNumericInput(str(int(value)))
+    if isinstance(value, numbers.Integral):
+        return FixedNumericInput(str(int(value)))
+    value = float(value)
+    if not math.isfinite(value):
+        raise LambdaCalculationError(
+            "the live calculation language has no representation for %r" % value)
+    return FixedNumericInput(repr(value))
+
+
+def as_calculation(value):
+    """Convert a python value produced while tracing into a Calculation"""
+    if isinstance(value, _Symbolic):
+        return value._as_calculation()
+    if isinstance(value, Calculation):
+        return value
+    if isinstance(value, str):
+        return FixedInput(value)
+    if isinstance(value, (bool, numbers.Integral, numbers.Real)):
+        return _numeric_calculation(value)
+    if isinstance(value, tuple):
+        if len(value) == 0:
+            raise LambdaCalculationError(
+                "cannot use an empty tuple in a live calculation")
+        return MultiCalculation(*[as_calculation(v) for v in value])
+    if isinstance(value, (list, set)):
+        raise LambdaCalculationError(
+            "cannot use a %s in a live calculation; write a tuple, e.g. (Mvir, Rvir), "
+            "to return more than one calculation" % type(value).__name__)
+    if value is None:
+        raise LambdaCalculationError(
+            "cannot use None in a live calculation")
+    raise LambdaCalculationError(
+        "cannot use %r (of type %s) in a live calculation; only numbers, strings, "
+        "tuples and other calculations can be included"
+        % (value, type(value).__name__))
+
+
+def _can_be_calculation(value):
+    """True if a python value can be interpolated into a live calculation"""
+    if isinstance(value, (Calculation, str, bool, numbers.Integral, numbers.Real)):
+        return True
+    if isinstance(value, tuple):
+        return all(_can_be_calculation(v) for v in value)
+    return _is_nullary_function(value)
+
+
+# --------------------------------------------------------------- symbolic stand-ins
+
+def _check_calculation_is_linkable(calculation, described_as):
+    if not isinstance(calculation, (StoredProperty, LiveProperty, Link)):
+        raise LambdaCalculationError(
+            "cannot follow a link from %s; only a property or function result can "
+            "appear to the left of a '.'" % described_as)
+
+
+def _make_link(locator, target):
+    """Construct Link(locator, target), matching the nesting generated by the parser.
+
+    The parser generates right-nested links, i.e. a.b.c is Link(a, Link(b, c)),
+    whereas python attribute access reaches us left-to-right.
+    """
+    _check_calculation_is_linkable(locator, str(locator))
+    if isinstance(locator, Link):
+        return Link(locator.locator, _make_link(locator.property, target))
+    return Link(locator, target)
+
+
+def _make_element(calculation, index):
+    if isinstance(index, slice):
+        raise LambdaCalculationError(
+            "cannot slice %s; the live calculation language only supports selecting a "
+            "single element, e.g. my_profile[3]" % calculation)
+    index_calculation = as_calculation(index)
+    if not isinstance(index_calculation, FixedNumericInput):
+        raise LambdaCalculationError(
+            "the index into %s must be a number, not %s"
+            % (calculation, index_calculation))
+    return LiveProperty("element", calculation, index_calculation)
+
+
+def _guard(construct, advice=None):
+    def guard_method(self, *args, **kwargs):
+        message = "cannot convert %s applied to %s into a live calculation" \
+                  % (construct, self._description())
+        if advice is not None:
+            message += "; " + advice
+        raise ControlFlowError(message)
+    return guard_method
+
+
+class _Symbolic:
+    """Base class for the stand-in objects substituted into a lambda while tracing.
+
+    Operations on these build up Calculation objects instead of computing anything.
+    """
+
+    __slots__ = ()
+
+    # stop numpy from taking over the reflected arithmetic operators, e.g. for
+    # np.float64(2.0) * Mvir
+    __array_ufunc__ = None
+
+    # __eq__ is overloaded below, which would otherwise make these unhashable
+    __hash__ = object.__hash__
+
+    def _as_calculation(self):
+        """Return the Calculation this stand-in represents when used as a value"""
+        raise NotImplementedError
+
+    def _description(self):
+        """Return a description of this stand-in, for use in error messages"""
+        return str(self._as_calculation())
+
+    def _apply_call(self, arguments):
+        """Return the Calculation for calling this stand-in with the given arguments"""
+        raise LambdaCalculationError(
+            "cannot call %s; only a property name or a linked property can be called, "
+            "e.g. lambda: Vvir() or lambda: BH.Vvir()" % self._description())
+
+    def _apply_subscript(self, index):
+        """Return the Calculation for subscripting this stand-in"""
+        return _make_element(self._as_calculation(), index)
+
+    def __call__(self, *args, **kwargs):
+        if kwargs:
+            raise LambdaCalculationError(
+                "the live calculation language does not support keyword arguments "
+                "(got %s in a call to %s)"
+                % (", ".join(sorted(kwargs)), self._description()))
+        return _Value(self._apply_call([as_calculation(a) for a in args]))
+
+    def __getitem__(self, index):
+        return _Value(self._apply_subscript(index))
+
+    def __getattr__(self, name):
+        # note this is only reached for attributes not otherwise found, so it does not
+        # interfere with the internals of the stand-in objects themselves
+        if not _NAME_RE.match(name):
+            raise AttributeError(
+                "%r is not a valid live calculation property name" % name)
+        return _Attribute(self, name)
+
+    def __repr__(self):
+        return "<live calculation being traced: %s>" % self._description()
+
+    # Backstop for control flow that our static check cannot see, because it happens
+    # inside an ordinary python function called by the lambda.
+    __bool__ = _guard("a truth test",
+                      "python evaluates 'and', 'or', 'not', 'in', 'is', chained "
+                      "comparisons and if/else expressions eagerly, so they cannot be "
+                      "captured; use '&', '|' and '~' instead")
+    __len__ = _guard("len()")
+    __iter__ = _guard("iteration")
+    __contains__ = _guard("an 'in' test")
+    __index__ = _guard("conversion to an index")
+    __int__ = _guard("int()")
+    __float__ = _guard("float()")
+    __complex__ = _guard("complex()")
+    __round__ = _guard("round()")
+    __format__ = _guard("string formatting",
+                        "a live calculation cannot be embedded in an f-string")
+
+
+def _binary_op_method(function_name, reflected=False):
+    def operator_method(self, other):
+        this = self._as_calculation()
+        that = as_calculation(other)
+        if reflected:
+            this, that = that, this
+        return _Value(LiveProperty(function_name, this, that))
+    return operator_method
+
+
+def _unary_op_method(function_name):
+    def operator_method(self):
+        return _Value(LiveProperty(function_name, self._as_calculation()))
+    return operator_method
+
+
+def _unsupported_op_method(symbol, advice):
+    def operator_method(self, *args):
+        message = "the live calculation language has no '%s' operator" % symbol
+        if advice is not None:
+            message += "; " + advice
+        raise LambdaCalculationError(message)
+    return operator_method
+
+
+for _python_name, _tangos_name in _BINARY_OPS.items():
+    setattr(_Symbolic, f"__{_python_name}__", _binary_op_method(_tangos_name))
+    setattr(_Symbolic, f"__r{_python_name}__",
+            _binary_op_method(_tangos_name, reflected=True))
+
+for _python_name, _tangos_name in _COMPARISON_OPS.items():
+    setattr(_Symbolic, f"__{_python_name}__", _binary_op_method(_tangos_name))
+
+for _python_name, _tangos_name in _UNARY_OPS.items():
+    setattr(_Symbolic, f"__{_python_name}__", _unary_op_method(_tangos_name))
+
+for _python_name, (_symbol, _advice) in _UNSUPPORTED_OPS.items():
+    _method = _unsupported_op_method(_symbol, _advice)
+    setattr(_Symbolic, f"__{_python_name}__", _method)
+    if _python_name != "pos":
+        setattr(_Symbolic, f"__r{_python_name}__", _method)
+
+del _python_name, _tangos_name, _symbol, _advice, _method
+
+
+class _Value(_Symbolic):
+    """A stand-in wrapping a Calculation that is already fully determined"""
+
+    __slots__ = ("_calculation",)
+
+    def __init__(self, calculation):
+        self._calculation = calculation
+
+    def _as_calculation(self):
+        return self._calculation
+
+
+class _Name(_Symbolic):
+    """A stand-in for a bare name, which may be a property or a function"""
+
+    __slots__ = ("_name",)
+
+    def __init__(self, name):
+        self._name = name
+
+    def _as_calculation(self):
+        return StoredProperty(self._name)
+
+    def _description(self):
+        return self._name
+
+    def _apply_call(self, arguments):
+        return LiveProperty(self._name, *arguments)
+
+
+class _Attribute(_Symbolic):
+    """A stand-in for a name reached through a '.', i.e. a link to another object"""
+
+    __slots__ = ("_parent", "_name")
+
+    def __init__(self, parent, name):
+        self._parent = parent
+        self._name = name
+
+    def _link_to(self, target):
+        return _make_link(self._parent._as_calculation(), target)
+
+    def _as_calculation(self):
+        return self._link_to(StoredProperty(self._name))
+
+    def _description(self):
+        return "%s.%s" % (self._parent._description(), self._name)
+
+    def _apply_call(self, arguments):
+        return self._link_to(LiveProperty(self._name, *arguments))
+
+    def _apply_subscript(self, index):
+        return self._link_to(_make_element(StoredProperty(self._name), index))
+
+
+# --------------------------------------------------------------------------- tracing
+
+NAME_RESOLUTION_MODES = ("auto", "python", "tangos")
+
+
+def _is_nullary_function(value):
+    return (isinstance(value, types.FunctionType)
+            and value.__code__.co_argcount == 0
+            and value.__code__.co_kwonlyargcount == 0
+            and not (value.__code__.co_flags & (inspect.CO_VARARGS
+                                                | inspect.CO_VARKEYWORDS)))
+
+
+def _check_is_nullary_function(function):
+    if not isinstance(function, types.FunctionType):
+        raise LambdaCalculationError(
+            "expected a lambda (or other python function taking no arguments), "
+            "got %r" % (function,))
+    if not _is_nullary_function(function):
+        raise LambdaCalculationError(
+            "a live calculation lambda must take no arguments; write e.g. "
+            "lambda: Mvir/Rvir rather than lambda %s: ..."
+            % ", ".join(function.__code__.co_varnames[:function.__code__.co_argcount]
+                        or ["x"]))
+    if function.__code__.co_flags & (inspect.CO_GENERATOR | inspect.CO_COROUTINE
+                                     | inspect.CO_ASYNC_GENERATOR):
+        raise LambdaCalculationError(
+            "cannot convert a generator or coroutine into a live calculation")
+
+
+def _substitute(name, value, name_resolution, _tracing):
+    """Return the object to bind to name while tracing, given its python value"""
+    if name_resolution == "tangos":
+        return _Name(name)
+    if name_resolution == "auto" and not _can_be_calculation(value):
+        return _Name(name)
+    if isinstance(value, Calculation):
+        return _Value(value)
+    if _is_nullary_function(value):
+        return _Value(_trace(value, name_resolution, _tracing))
+    # anything else is passed through as its real python value, so that e.g.
+    # arithmetic between python variables happens as python arithmetic
+    return value
+
+
+def _global_names(code):
+    """Return the names that this code object looks up in its globals"""
+    return {instruction.argval for instruction in dis.get_instructions(code)
+            if instruction.opname == "LOAD_GLOBAL"}
+
+
+def _traced_globals(function, name_resolution, _tracing):
+    # builtins are deliberately excluded: the live calculation language has functions
+    # such as abs() and sum() of its own, and those should win over python's
+    traced = {"__builtins__": {}}
+    for name in _global_names(function.__code__):
+        if name in function.__globals__:
+            traced[name] = _substitute(name, function.__globals__[name],
+                                       name_resolution, _tracing)
+        else:
+            traced[name] = _Name(name)
+    return traced
+
+
+def _traced_closure(function, name_resolution, _tracing):
+    if not function.__closure__:
+        return None
+    cells = []
+    for name, cell in zip(function.__code__.co_freevars, function.__closure__):
+        try:
+            value = cell.cell_contents
+        except ValueError:  # an empty cell, e.g. a recursive definition
+            cells.append(cell)
+            continue
+        cells.append(types.CellType(
+            _substitute(name, value, name_resolution, _tracing)))
+    return tuple(cells)
+
+
+def _trace(function, name_resolution, _tracing):
+    _check_is_nullary_function(function)
+    check_traceable(function)
+
+    if function.__code__ in _tracing:
+        raise LambdaCalculationError(
+            "cannot convert %s: it refers to itself" % _describe(function))
+
+    _tracing = _tracing | {function.__code__}
+
+    shadow = types.FunctionType(
+        function.__code__,
+        _traced_globals(function, name_resolution, _tracing),
+        function.__name__,
+        function.__defaults__,
+        _traced_closure(function, name_resolution, _tracing))
+
+    return as_calculation(shadow())
+
+
+def _describe(function):
+    """Describe a lambda for use in an error message"""
+    try:
+        source = inspect.getsource(function).strip()
+    except (OSError, TypeError):
+        source = None
+    if source is not None and len(source) < 120:
+        return source
+    if function.__name__ == "<lambda>":
+        return "the lambda at %s:%d" % (function.__code__.co_filename,
+                                        function.__code__.co_firstlineno)
+    return function.__name__
+
+
+def to_calculation(function, name_resolution="auto"):
+    """Convert a lambda expression into a tangos live calculation.
+
+    For example, to_calculation(lambda: later(5).Mvir/Rvir) returns the same
+    calculation as parser.parse_property_name("later(5).Mvir/Rvir").
+
+    :param function: a lambda (or any python function) taking no arguments. Names
+      appearing within it that do not resolve to python variables are interpreted as
+      live-calculation property or function names.
+
+    :param name_resolution: how to treat names that *do* resolve to a python variable
+      in the scope surrounding the lambda:
+
+      * 'auto' (default): interpolate the python value if it is something a live
+        calculation can contain (a number, a string, a tuple of those, a Calculation
+        or another lambda taking no arguments); otherwise ignore the python variable
+        and interpret the name as a live-calculation name.
+      * 'python': always use the python value. This is the closest to normal python
+        scoping rules, and allows e.g. numpy.pi to be interpolated, but a variable
+        that happens to share the name of a database property will silently shadow it.
+      * 'tangos': never use the python value; every name is a live-calculation name.
+
+      In all cases, python's builtins are excluded, so that live-calculation functions
+      like abs() and sum() are not shadowed by the python functions of the same name.
+
+    :returns: a Calculation object, equivalent to one generated by the parser
+    """
+    if name_resolution not in NAME_RESOLUTION_MODES:
+        raise ValueError("name_resolution must be one of %s, not %r"
+                         % (", ".join(repr(m) for m in NAME_RESOLUTION_MODES),
+                            name_resolution))
+    return _trace(function, name_resolution, frozenset())
+
+
+def to_calculations(*functions, name_resolution="auto"):
+    """Convert multiple lambda expressions into a single MultiCalculation.
+
+    This is the lambda equivalent of parser.parse_property_names. See
+    :func:`to_calculation` for the meaning of name_resolution.
+    """
+    return MultiCalculation(*[to_calculation(f, name_resolution)
+                              for f in functions])

--- a/tangos/live_calculation/parser.py
+++ b/tangos/live_calculation/parser.py
@@ -15,6 +15,7 @@ from . import (
     LiveProperty,
     MultiCalculation,
     StoredProperty,
+    from_lambda,
 )
 
 
@@ -92,16 +93,32 @@ property_complete = pp.string_start()+value_or_property_name+pp.string_end()
 
 
 def parse_property_name( name):
+    """Parse a string in the live-calculation mini-language into a Calculation"""
     with _parsing_lock:
         return property_complete.parse_string(name)[0]
 
 def parse_property_name_if_required(name):
+    """Return a Calculation for name, whichever way the calculation has been specified.
+
+    The calculation may be given as a string in the mini-language (see
+    parse_property_name), as a lambda taking no arguments (see
+    live_calculation.from_lambda.to_calculation), or as a Calculation object, which is
+    returned unchanged."""
     if isinstance(name, Calculation):
         return name
-    else:
+    elif isinstance(name, str):
         return parse_property_name(name)
+    elif callable(name):
+        return from_lambda.to_calculation(name)
+    else:
+        raise TypeError("A live calculation must be specified as a string, as a lambda "
+                        "taking no arguments, or as a Calculation object "
+                        "(received %r)" % (name,))
 
 def parse_property_names(*names):
-    return MultiCalculation(*[parse_property_name(n) for n in names])
+    """Return a MultiCalculation of the named calculations.
+
+    Each may be a string, a lambda or a Calculation; see parse_property_name_if_required."""
+    return MultiCalculation(*[parse_property_name_if_required(n) for n in names])
 
 __all__ = ["parse_property_name", "parse_property_name_if_required", "parse_property_names"]

--- a/tangos/live_calculation/parser.py
+++ b/tangos/live_calculation/parser.py
@@ -40,6 +40,7 @@ IN_OPS = [("**", "power"),
           ("<=", "less_equal")]
 
 UNARY_OPS = [("!", "logical_not"),
+             ("~", "logical_not"), # ~ mirrors python, so that lambdas can be used interchangeably
              ("-", "negate")]
 
 IN_OPS_PYPARSING = []

--- a/tangos/live_calculation/parser.py
+++ b/tangos/live_calculation/parser.py
@@ -6,6 +6,8 @@ import pyparsing as pp
 _parsing_lock = threading.Lock() # pyparsing is NOT thread safe
 
 from . import (
+    IN_OPS,
+    UNARY_OPS,
     Calculation,
     FixedInput,
     FixedNumericInput,
@@ -25,23 +27,8 @@ pp.ParserElement.enable_packrat()
 
 numerical_value = pp.Regex(r'-?\d+(\.\d*)?([eE]-?\d+)?').set_parse_action(pack_args(FixedNumericInput))
 
-IN_OPS = [("**", "power"),
-          ("*", "multiply"),
-          ("/", "divide"),
-          ("+", "add"),
-          ("-", "subtract"),
-          (">", "greater"),
-          ("<", "less"),
-          ("|", "logical_or"),
-          ("&", "logical_and"),
-          ("==", "equal"),
-          ("!=", "not_equal"),
-          (">=", "greater_equal"),
-          ("<=", "less_equal")]
-
-UNARY_OPS = [("!", "logical_not"),
-             ("~", "logical_not"), # ~ mirrors python, so that lambdas can be used interchangeably
-             ("-", "negate")]
+# n.b. IN_OPS and UNARY_OPS are defined alongside the Calculation classes, which need
+# them to write calculations back out in operator form
 
 IN_OPS_PYPARSING = []
 UNARY_OPS_PYPARSING = []
@@ -75,7 +62,14 @@ redirection = pp.Forward().setParseAction(pack_args(Link))
 
 element_identifier = pp.Literal("[").suppress()+numerical_value+pp.Literal("]").suppress();
 
-multiple_properties = pp.Forward().setParseAction(pack_args(MultiCalculation))
+def generate_multiple_properties_or_group(*tokens):
+    """Brackets around a single calculation are just grouping; more make a MultiCalculation"""
+    if len(tokens)==1:
+        return tokens[0]
+    else:
+        return MultiCalculation(*tokens)
+
+multiple_properties = pp.Forward().setParseAction(pack_args(generate_multiple_properties_or_group))
 
 property_identifier = (redirection | array_element | live_calculation_property | stored_property | multiple_properties)
 

--- a/tests/test_live_calculation.py
+++ b/tests/test_live_calculation.py
@@ -393,6 +393,15 @@ def test_calculate_all_object_restriction():
     assert np.all(tangos.get_timestep("sim/ts1").calculate_all("dbid()",object_type='halo')[0] == [1,2])
     assert np.all(tangos.get_timestep("sim/ts1").calculate_all("dbid()", object_type='BH')[0] == [3, 4])
 
+def test_calculate_all_calculation_object_with_further_arguments():
+    """A prebuilt Calculation can be combined with further calculations"""
+    ts = tangos.get_timestep("sim/ts1")
+    calculation = lc.parser.parse_property_name("dbid()")
+    dbid, = ts.calculate_all(calculation)
+    dbid_again, dbid_from_string = ts.calculate_all(calculation, "dbid()")
+    assert np.all(dbid == dbid_again)
+    assert np.all(dbid == dbid_from_string)
+
 def test_non_existent_redirection_multihalo():
     # See issue #46
     vals1, vals2 = tangos.get_timestep("sim/ts3").calculate_all("BH_mass","later(1).BH_mass")

--- a/tests/test_live_calculation.py
+++ b/tests/test_live_calculation.py
@@ -180,6 +180,12 @@ REPRESENTATION_CASES = [
     "at(Rvir/2,dm_density_profile)",
     "a.b.c",
     "add(a,b).c",
+    "a[0]",
+    "a()[0]",
+    "a[-1]",
+    "a.b[0]",
+    "abs(a)[2]",
+    "a[3]*2",
     "a.b*c",
     "later(5).a[0]",
     "later(5).Mvir/Rvir",
@@ -217,6 +223,28 @@ def test_operators_are_written_out_as_operators():
     # ... and cannot be used to the left of a redirection, where the underlying
     # function form is used instead
     assert as_string("add(a,b).c") == "add(a,b).c"
+
+def test_array_elements_are_written_out_with_brackets():
+    """Extraction of an array element is written back out as my_array[i]"""
+    def as_string(expression):
+        return str(lc.parser.parse_property_name(expression))
+
+    assert as_string("element(dm_density_profile,3)") == "dm_density_profile[3]"
+    assert as_string("later(5).element(a,0)") == "later(5).a[0]"
+    assert as_string("element(a(),0)*2") == "a()[0]*2"
+
+def test_array_elements_that_cannot_use_brackets():
+    """Where the mini-language does not allow the bracket form, functions are used"""
+    def element(array, index):
+        return lc.LiveProperty("element", array, lc.FixedNumericInput(index))
+
+    inner = element(lc.StoredProperty("a"), "0")
+    # a[0][1] and a[0].b are not valid in the mini-language
+    assert str(element(inner, "1")) == "element(a,0)[1]"
+    assert str(lc.Link(inner, lc.StoredProperty("b"))) == "element(a,0).b"
+    # neither is a.b[0] a way of writing the element of a redirected property
+    assert str(element(lc.Link(lc.StoredProperty("a"), lc.StoredProperty("b")), "0")) \
+           == "element(a.b,0)"
 
 def test_brackets_around_a_single_calculation_are_grouping():
     assert isinstance(lc.parser.parse_property_name("(Mvir)"), lc.StoredProperty)

--- a/tests/test_live_calculation.py
+++ b/tests/test_live_calculation.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from pytest import raises as assert_raises
 
 import tangos
@@ -149,6 +150,77 @@ def test_logical_not_operators():
     assert halo.calculate("~has_property(nonexistent_property)")
     assert np.allclose(halo.calculate("~~dummy_property_3"),
                        halo.calculate("!!dummy_property_3"))
+
+#: expressions used to check that calculations are written back out in a form which
+#: parses to the same calculation
+REPRESENTATION_CASES = [
+    "Mvir",
+    "Vvir()",
+    "Mvir/Vvir()",
+    "a+b*c",
+    "(a+b)*c",
+    "a-b-c",
+    "(a-b)-c",
+    "a**b**c",
+    "(a**b)**c",
+    "a<10&b>5",
+    "(a==1)|(b!=2)",
+    "a>=1",
+    "a<=1",
+    "-a+b",
+    "-(a+b)",
+    "a-(-b)",
+    "a--2.5",
+    "!has_property(a)",
+    "!(a>1)",
+    "-!a",
+    "2**(-a)",
+    "abs(a-b)",
+    "sqrt(a)/2",
+    "at(Rvir/2,dm_density_profile)",
+    "a.b.c",
+    "add(a,b).c",
+    "a.b*c",
+    "later(5).a[0]",
+    "later(5).Mvir/Rvir",
+    "(a,b)",
+    "(a+b,c*d)",
+    "f((a,b))",
+    'link(BH,BH_mass,"max",BH_central_distance<10)',
+    'find_progenitor(SFR,"max").mass',
+]
+
+@pytest.mark.parametrize("expression", REPRESENTATION_CASES)
+def test_representation_round_trips(expression):
+    """Writing out a calculation must generate a string that parses back to a copy"""
+    calculation = lc.parser.parse_property_name(expression)
+    reparsed = lc.parser.parse_property_name(str(calculation))
+    assert str(reparsed) == str(calculation)
+    assert type(reparsed) is type(calculation)
+
+def test_operators_are_written_out_as_operators():
+    """Operators are written back out in operator form, not as the underlying functions"""
+    def as_string(expression):
+        return str(lc.parser.parse_property_name(expression))
+
+    assert as_string("Mvir/Vvir()") == "Mvir/Vvir()"
+    assert as_string("at(Rvir/2,dm_density_profile)") == "at(Rvir/2,dm_density_profile)"
+    assert as_string("a<10 & b>5") == "a<10&b>5"
+    assert as_string("~a") == "!a"
+    # brackets appear only where the mini-language would otherwise regroup; note
+    # that the operators are right-associative, so a*(b+c) needs them but a+b*c
+    # does not
+    assert as_string("(a+b)*c") == "(a+b)*c"
+    assert as_string("a*(b+c)") == "a*(b+c)"
+    assert as_string("a+b*c") == "a+b*c"
+    assert as_string("a+(b*c)") == "a+b*c"
+    # ... and cannot be used to the left of a redirection, where the underlying
+    # function form is used instead
+    assert as_string("add(a,b).c") == "add(a,b).c"
+
+def test_brackets_around_a_single_calculation_are_grouping():
+    assert isinstance(lc.parser.parse_property_name("(Mvir)"), lc.StoredProperty)
+    assert isinstance(lc.parser.parse_property_name("(a,b)"), lc.MultiCalculation)
 
 def test_abcissa_passing_function():
     """In this example, the x-coordinates need to be successfully passed "through" the abs function for the

--- a/tests/test_live_calculation.py
+++ b/tests/test_live_calculation.py
@@ -140,6 +140,16 @@ def test_unary_minus_function():
     assert np.allclose(halo.calculate("-dummy_property_3"), 2.5)
     assert np.allclose(halo.calculate("--dummy_property_3"), -2.5)
 
+def test_logical_not_operators():
+    """logical_not can be spelled either ! (traditional) or ~ (as in python)"""
+    halo = tangos.get_halo("sim/ts1/1")
+    assert not halo.calculate("!has_property(dummy_property_1)")
+    assert not halo.calculate("~has_property(dummy_property_1)")
+    assert halo.calculate("!has_property(nonexistent_property)")
+    assert halo.calculate("~has_property(nonexistent_property)")
+    assert np.allclose(halo.calculate("~~dummy_property_3"),
+                       halo.calculate("!!dummy_property_3"))
+
 def test_abcissa_passing_function():
     """In this example, the x-coordinates need to be successfully passed "through" the abs function for the
     at function to return the correct result."""

--- a/tests/test_live_calculation_from_lambda.py
+++ b/tests/test_live_calculation_from_lambda.py
@@ -73,6 +73,7 @@ PARITY_CASES = [
     (lambda: a()[0], "a()[0]"),
     (lambda: later(5).a[0], "later(5).a[0]"),
     (lambda: (Mvir, Rvir), "(Mvir,Rvir)"),
+    (lambda: (Mvir,), "(Mvir)"),
     (lambda: f((Mvir, Rvir)), "f((Mvir,Rvir))"),
     (lambda: reassemble(SFR_histogram, 'sum'), "reassemble(SFR_histogram,'sum')"),
     (lambda: raw(SFR_histogram), "raw(SFR_histogram)"),

--- a/tests/test_live_calculation_from_lambda.py
+++ b/tests/test_live_calculation_from_lambda.py
@@ -392,3 +392,47 @@ def test_calculate_all_from_lambda():
     from_string_result, = timestep.calculate_all("dummy_property_3*2")
     assert np.allclose(from_lambda_result, from_string_result)
     assert np.allclose(from_lambda_result, [-5.0])
+
+
+# ------------------------------- lambdas passed directly, wherever strings are accepted
+
+def test_calculate_accepts_a_lambda():
+    halo = tangos.get_halo("sim/ts1/1")
+    assert np.allclose(halo.calculate(lambda: dummy_property_3*2),
+                       halo.calculate("dummy_property_3*2"))
+
+
+def test_calculate_all_accepts_lambdas_alongside_strings():
+    timestep = tangos.get_timestep("sim/ts1")
+    from_lambda_result, from_string_result = timestep.calculate_all(
+        lambda: dummy_property_3*2, "dummy_property_3*2")
+    assert np.allclose(from_lambda_result, from_string_result)
+    assert np.allclose(from_lambda_result, [-5.0])
+
+
+def test_calculate_for_descendants_accepts_a_lambda():
+    halo = tangos.get_halo("sim/ts1/1")
+    from_lambda_result, = halo.calculate_for_descendants(lambda: dummy_property_3)
+    from_string_result, = halo.calculate_for_descendants("dummy_property_3")
+    assert np.allclose(from_lambda_result, from_string_result)
+    assert np.allclose(from_lambda_result, [-2.5, 5.0])
+
+
+def test_calculate_for_progenitors_accepts_a_lambda():
+    halo = tangos.get_halo("sim/ts2/1")
+    from_lambda_result, = halo.calculate_for_progenitors(lambda: dummy_property_3)
+    assert np.allclose(from_lambda_result, [5.0, -2.5])
+
+
+def test_calculations_can_be_built_from_lambdas():
+    """Anywhere a Calculation can be assembled from strings, a lambda also works"""
+    assert str(lc.MultiCalculation(lambda: Mvir, "Rvir")) \
+           == str(parser.parse_property_name("(Mvir,Rvir)"))
+    assert str(lc.Link(lambda: BH, "BH_mass")) \
+           == str(parser.parse_property_name("BH.BH_mass"))
+
+
+def test_unusable_calculation_type_rejected():
+    halo = tangos.get_halo("sim/ts1/1")
+    with assert_raises(TypeError):
+        halo.calculate(42)

--- a/tests/test_live_calculation_from_lambda.py
+++ b/tests/test_live_calculation_from_lambda.py
@@ -1,0 +1,394 @@
+"""Tests for the lambda front-end to the live calculation system.
+
+Note that names used inside the test lambdas must not clash with names defined at
+module level in this file, since the whole point of the module under test is that
+names resolving in the surrounding python scope may be interpolated. The names
+deliberately used for that purpose are prefixed with 'python_'.
+"""
+
+import numpy as np
+from pytest import mark, raises as assert_raises
+
+import tangos
+import tangos.core.halo
+import tangos.live_calculation as lc
+import tangos.live_calculation.parser as parser
+import tangos.testing as testing
+import tangos.testing.simulation_generator
+from tangos.live_calculation import from_lambda
+from tangos.live_calculation.from_lambda import (
+    ControlFlowError,
+    LambdaCalculationError,
+    to_calculation,
+    to_calculations,
+)
+
+
+def setup_module():
+    testing.init_blank_db_for_testing()
+
+    generator = tangos.testing.simulation_generator.SimulationGeneratorForTests()
+
+    ts1 = generator.add_timestep()
+    ts1_h1, ts1_h2 = generator.add_objects_to_timestep(2)
+    ts1_h1['dummy_property_1'] = np.arange(0, 100.0)
+    ts1_h1['dummy_property_3'] = -2.5
+
+    ts1_h1_bh = tangos.core.halo.BH(ts1, 1)
+    tangos.get_default_session().add(ts1_h1_bh)
+    ts1_h1_bh['BH_mass'] = 1000.0
+    ts1_h1['BH'] = ts1_h1_bh
+
+    generator.add_timestep()
+    ts2_h1, = generator.add_objects_to_timestep(1)
+    ts2_h1['dummy_property_3'] = 5.0
+    generator.link_last_halos()
+
+
+def teardown_module():
+    tangos.core.close_db()
+
+
+def assert_matches_string(function, string, **kwargs):
+    """Assert that the lambda generates the same calculation as the string"""
+    from_lambda_result = to_calculation(function, **kwargs)
+    from_string_result = parser.parse_property_name(string)
+    assert str(from_lambda_result) == str(from_string_result)
+    return from_lambda_result
+
+
+#: (lambda, equivalent string) pairs, checked in test_matches_parser
+PARITY_CASES = [
+    (lambda: dummy_property_1, "dummy_property_1"),
+    (lambda: Vvir(), "Vvir()"),
+    (lambda: at(3.0, dummy_property_1), "at(3.0,dummy_property_1)"),
+    (lambda: at(Rvir/2, dm_density_profile), "at(Rvir/2,dm_density_profile)"),
+    (lambda: BH.BH_mass, "BH.BH_mass"),
+    (lambda: a.b.c, "a.b.c"),
+    (lambda: later(5).Mvir, "later(5).Mvir"),
+    (lambda: earlier(2).at(Rvir/2, GasMass_encl), "earlier(2).at(Rvir/2,GasMass_encl)"),
+    (lambda: a.b(), "a.b()"),
+    (lambda: a().b, "a().b"),
+    (lambda: dm_density_profile[3], "dm_density_profile[3]"),
+    (lambda: a()[0], "a()[0]"),
+    (lambda: later(5).a[0], "later(5).a[0]"),
+    (lambda: (Mvir, Rvir), "(Mvir,Rvir)"),
+    (lambda: f((Mvir, Rvir)), "f((Mvir,Rvir))"),
+    (lambda: reassemble(SFR_histogram, 'sum'), "reassemble(SFR_histogram,'sum')"),
+    (lambda: raw(SFR_histogram), "raw(SFR_histogram)"),
+    (lambda: link(BH, BH_mass, "max"), 'link(BH,BH_mass,"max")'),
+    (lambda: link(BH, BH_mass, "max", BH_central_distance < 10),
+     'link(BH,BH_mass,"max",BH_central_distance<10)'),
+    (lambda: find_progenitor(SFR, "max").mass, 'find_progenitor(SFR,"max").mass'),
+    (lambda: abs(dummy_property_2), "abs(dummy_property_2)"),
+    (lambda: sqrt(Mvir), "sqrt(Mvir)"),
+    # arithmetic and comparison operators
+    (lambda: Mgas + Mstar, "Mgas+Mstar"),
+    (lambda: Mgas - Mstar, "Mgas-Mstar"),
+    (lambda: Mgas * Mstar, "Mgas*Mstar"),
+    (lambda: Mgas / Mstar, "Mgas/Mstar"),
+    (lambda: Mgas ** Mstar, "Mgas**Mstar"),
+    (lambda: -Mvir, "-Mvir"),
+    (lambda: ~has_property(Mvir), "!has_property(Mvir)"),
+    (lambda: ~has_property(Mvir), "~has_property(Mvir)"),
+    (lambda: Mgas > Mstar, "Mgas>Mstar"),
+    (lambda: Mgas < Mstar, "Mgas<Mstar"),
+    (lambda: Mgas >= Mstar, "Mgas>=Mstar"),
+    (lambda: Mgas <= Mstar, "Mgas<=Mstar"),
+    (lambda: Mgas == Mstar, "Mgas==Mstar"),
+    (lambda: Mgas != Mstar, "Mgas!=Mstar"),
+    (lambda: (Mgas > 1) & (Mstar < 2), "Mgas>1 & Mstar<2"),
+    (lambda: (Mgas > 1) | (Mstar < 2), "Mgas>1 | Mstar<2"),
+    # reflected operators, where the calculation is on the right hand side
+    (lambda: 2 + Mvir, "2+Mvir"),
+    (lambda: 2 - Mvir, "2-Mvir"),
+    (lambda: 2 * Mvir, "2*Mvir"),
+    (lambda: 2 / Mvir, "2/Mvir"),
+    (lambda: 2 ** Mvir, "2**Mvir"),
+    (lambda: 2 < Mvir, "Mvir>2"),
+    (lambda: 2 >= Mvir, "Mvir<=2"),
+    # literals
+    (lambda: f(1), "f(1)"),
+    (lambda: f(1.5), "f(1.5)"),
+    (lambda: f(1e6), "f(1e6)"),
+    (lambda: f("a string"), 'f("a string")'),
+    (lambda: f('a string'), "f('a string')"),
+    # things python evaluates for us before we ever see them
+    (lambda: f(2 + 3), "f(5)"),
+    (lambda: f("a" + " string"), 'f("a string")'),
+    (lambda: f(f"{2}"), 'f("2")'),
+    (lambda: f("%d" % 2), 'f("2")'),
+]
+
+
+@mark.parametrize("function, string", PARITY_CASES)
+def test_matches_parser(function, string):
+    assert_matches_string(function, string)
+
+
+def test_returned_types():
+    assert isinstance(to_calculation(lambda: Mvir), lc.StoredProperty)
+    assert isinstance(to_calculation(lambda: Vvir()), lc.LiveProperty)
+    assert isinstance(to_calculation(lambda: later(1).Mvir), lc.Link)
+    assert isinstance(to_calculation(lambda: (Mvir, Rvir)), lc.MultiCalculation)
+    assert isinstance(to_calculation(lambda: 1.5), lc.FixedNumericInput)
+    assert isinstance(to_calculation(lambda: "hello"), lc.FixedInput)
+    assert isinstance(to_calculation(lambda: Mvir + 1), lc.BuiltinFunction)
+
+
+def test_numeric_literals_keep_their_type():
+    assert isinstance(to_calculation(lambda: f(2))._inputs[0].proxy_value(), int)
+    assert isinstance(to_calculation(lambda: f(2.0))._inputs[0].proxy_value(), float)
+    assert to_calculation(lambda: f(1e-9))._inputs[0].proxy_value() == 1e-9
+    # note the parser generates negate(1.5) for a literal -1.5, whereas python has
+    # already folded the sign into the constant by the time we see it
+    assert to_calculation(lambda: f(-1.5))._inputs[0].proxy_value() == -1.5
+    assert to_calculation(lambda: f(True))._inputs[0].proxy_value() == 1
+
+
+def test_all_parser_operators_are_available():
+    """Every operator understood by the string parser must have a lambda spelling"""
+    available = set(from_lambda._BINARY_OPS.values())
+    available.update(from_lambda._COMPARISON_OPS.values())
+    available.update(from_lambda._UNARY_OPS.values())
+    for _symbol, function_name in parser.IN_OPS + parser.UNARY_OPS:
+        assert function_name in available
+
+
+def test_to_calculations():
+    result = to_calculations(lambda: Mvir, lambda: Rvir/2)
+    assert isinstance(result, lc.MultiCalculation)
+    assert str(result) == str(parser.parse_property_names("Mvir", "Rvir/2"))
+
+
+# ---------------------------------------------------------------- name resolution
+
+python_radius = 3.0
+python_basis = 'max'
+python_calculation = parser.parse_property_name("Rvir/2")
+python_sub_lambda = lambda: Mgas + Mstar
+python_module = np
+python_shadowing_property = 4.0
+python_multiple_calculation = parser.parse_property_name("(Mgas,Mstar)")
+
+
+def test_python_values_are_interpolated():
+    assert_matches_string(lambda: at(python_radius, dm_density_profile),
+                          "at(3.0,dm_density_profile)")
+    assert_matches_string(lambda: at(python_radius/3, dm_density_profile),
+                          "at(1.0,dm_density_profile)")
+    assert_matches_string(lambda: link(BH, BH_mass, python_basis),
+                          'link(BH,BH_mass,"max")')
+
+
+def test_calculations_are_inlined():
+    assert_matches_string(lambda: at(python_calculation, dm_density_profile),
+                          "at(Rvir/2,dm_density_profile)")
+
+
+def test_sub_lambdas_are_inlined():
+    assert_matches_string(lambda: at(python_sub_lambda, dm_density_profile),
+                          "at(Mgas+Mstar,dm_density_profile)")
+
+
+def test_default_mode_ignores_uninterpolatable_values():
+    """In 'auto' mode a name bound to something that isn't a calculation is a property"""
+    assert_matches_string(lambda: python_module.pi, "python_module.pi")
+
+
+def test_python_mode_uses_the_python_value():
+    assert_matches_string(lambda: python_module.pi * Mvir,
+                          "%r*Mvir" % np.pi, name_resolution='python')
+    assert_matches_string(lambda: python_shadowing_property,
+                          "4.0", name_resolution='python')
+
+
+def test_tangos_mode_ignores_the_python_scope():
+    assert_matches_string(lambda: python_radius, "python_radius",
+                          name_resolution='tangos')
+    assert_matches_string(lambda: at(python_radius, dm_density_profile),
+                          "at(python_radius,dm_density_profile)",
+                          name_resolution='tangos')
+
+
+def test_python_builtins_do_not_shadow_live_calculation_functions():
+    """abs and sum exist in python, but here they must be live calculation functions"""
+    assert_matches_string(lambda: abs(dummy_property_2), "abs(dummy_property_2)")
+    assert_matches_string(lambda: sum(dummy_property_2), "sum(dummy_property_2)")
+
+
+def test_closure_variables_are_interpolated():
+    def enclosing_scope():
+        enclosed_radius = 5.0
+        return to_calculation(lambda: at(enclosed_radius, dm_density_profile))
+
+    assert str(enclosing_scope()) == str(parser.parse_property_name(
+        "at(5.0,dm_density_profile)"))
+
+
+def test_closure_variables_respect_tangos_mode():
+    def enclosing_scope():
+        dm_density_profile = "not actually a profile"
+        return to_calculation(lambda: at(5.0, dm_density_profile),
+                              name_resolution='tangos')
+
+    assert str(enclosing_scope()) == str(parser.parse_property_name(
+        "at(5.0,dm_density_profile)"))
+
+
+def test_unknown_name_resolution_mode():
+    with assert_raises(ValueError):
+        to_calculation(lambda: Mvir, name_resolution='something_else')
+
+
+# ----------------------------------------------------------------------- rejections
+
+def assert_rejected(function, expected_error=LambdaCalculationError, contains=None):
+    with assert_raises(expected_error) as excinfo:
+        to_calculation(function)
+    if contains is not None:
+        assert contains in str(excinfo.value)
+    return str(excinfo.value)
+
+
+def test_conditional_rejected():
+    assert_rejected(lambda: Mgas if Mstar else Mvir, ControlFlowError, contains="if/else")
+
+
+def test_boolean_operators_rejected():
+    assert_rejected(lambda: Mgas and Mstar, ControlFlowError, contains="'and'")
+    assert_rejected(lambda: Mgas or Mstar, ControlFlowError, contains="'or'")
+    assert_rejected(lambda: not Mgas, ControlFlowError, contains="'~x'")
+
+
+def test_chained_comparison_rejected():
+    assert_rejected(lambda: 1 < Mgas < 2, ControlFlowError)
+
+
+def test_membership_and_identity_rejected():
+    assert_rejected(lambda: Mgas in Mstar, ControlFlowError, contains="'in' test")
+    assert_rejected(lambda: Mgas is None, ControlFlowError, contains="'is' test")
+
+
+def test_comprehensions_and_generators_rejected():
+    assert_rejected(lambda: [x for x in Mgas], ControlFlowError)
+    assert_rejected(lambda: tuple(x for x in Mgas), ControlFlowError)
+    assert_rejected(lambda: {x: 1 for x in Mgas}, ControlFlowError)
+
+
+def test_control_flow_inside_a_nested_lambda_rejected():
+    assert_rejected(lambda: f(lambda: Mgas if Mstar else Mvir), ControlFlowError)
+
+
+def test_argument_unpacking_rejected():
+    assert_rejected(lambda: f(*Mgas), ControlFlowError, contains="unpacking")
+
+
+def test_control_flow_in_a_called_function_rejected():
+    """The static check cannot see inside an ordinary function, so there is a backstop"""
+    def branching_function(value):
+        return 1 if value else 2
+
+    with assert_raises(ControlFlowError):
+        to_calculation(lambda: branching_function(Mgas), name_resolution='python')
+
+
+def test_lambda_with_arguments_rejected():
+    message = assert_rejected(lambda halo: halo.Mvir, contains="no arguments")
+    assert "lambda halo" in message
+
+
+def test_non_function_rejected():
+    assert_rejected("Mvir")
+    assert_rejected(42)
+
+
+def test_keyword_arguments_rejected():
+    assert_rejected(lambda: at(radius=3.0), contains="keyword arguments")
+
+
+def test_list_rejected():
+    assert_rejected(lambda: [Mgas, Mstar], contains="tuple")
+
+
+def test_empty_tuple_rejected():
+    assert_rejected(lambda: (), contains="empty tuple")
+
+
+def test_none_rejected():
+    assert_rejected(lambda: None, contains="None")
+
+
+def test_unsupported_operators_rejected():
+    assert_rejected(lambda: Mgas // 2, contains="'//'")
+    assert_rejected(lambda: Mgas % 2, contains="'%'")
+    assert_rejected(lambda: Mgas ^ Mstar, contains="'^'")
+    assert_rejected(lambda: 2 // Mgas, contains="'//'")
+
+
+def test_slicing_rejected():
+    assert_rejected(lambda: dm_density_profile[1:3], contains="slice")
+
+
+def test_non_numeric_index_rejected():
+    assert_rejected(lambda: dm_density_profile["3"], contains="must be a number")
+
+
+def test_calling_an_expression_rejected():
+    assert_rejected(lambda: (Mgas + Mstar)(), contains="cannot call")
+
+
+def test_linking_from_an_expression_rejected():
+    assert_rejected(lambda: python_multiple_calculation.Mvir,
+                    contains="cannot follow a link")
+
+
+def test_f_string_of_calculation_rejected():
+    assert_rejected(lambda: f(f"{Mgas}"), ControlFlowError, contains="f-string")
+
+
+def test_self_reference_rejected():
+    recursive = lambda: recursive + 1
+    assert_rejected(recursive, contains="refers to itself")
+
+
+def test_error_message_includes_source():
+    message = assert_rejected(lambda: Mgas if Mstar else Mvir, ControlFlowError)
+    assert "Mgas if Mstar else Mvir" in message
+
+
+# --------------------------------------------------------------------- evaluation
+
+EVALUATION_CASES = [
+    (lambda: dummy_property_3, "dummy_property_3"),
+    (lambda: dummy_property_3 * 2, "dummy_property_3*2"),
+    (lambda: 2 * dummy_property_3, "2*dummy_property_3"),
+    (lambda: abs(dummy_property_3), "abs(dummy_property_3)"),
+    (lambda: -dummy_property_3, "-dummy_property_3"),
+    (lambda: dummy_property_1[3], "dummy_property_1[3]"),
+    (lambda: dummy_property_3 < 0, "dummy_property_3<0"),
+    (lambda: BH.BH_mass, "BH.BH_mass"),
+    (lambda: later(1).dummy_property_3, "later(1).dummy_property_3"),
+]
+
+
+@mark.parametrize("function, string", EVALUATION_CASES)
+def test_evaluation_matches_string_version(function, string):
+    halo = tangos.get_halo("sim/ts1/1")
+    assert np.allclose(halo.calculate(to_calculation(function)),
+                       halo.calculate(string))
+
+
+def test_evaluation_of_multiple_calculations():
+    halo = tangos.get_halo("sim/ts1/1")
+    calculation = to_calculation(lambda: (dummy_property_3, dummy_property_1[2]))
+    assert np.allclose(calculation.values_sanitized([halo]), [[-2.5], [2.0]])
+
+
+def test_calculate_all_from_lambda():
+    timestep = tangos.get_timestep("sim/ts1")
+    from_lambda_result, = timestep.calculate_all(
+        to_calculation(lambda: dummy_property_3 * 2))
+    from_string_result, = timestep.calculate_all("dummy_property_3*2")
+    assert np.allclose(from_lambda_result, from_string_result)
+    assert np.allclose(from_lambda_result, [-5.0])

--- a/tests/test_live_calculation_from_lambda.py
+++ b/tests/test_live_calculation_from_lambda.py
@@ -170,6 +170,13 @@ python_sub_lambda = lambda: Mgas + Mstar
 python_module = np
 python_shadowing_property = 4.0
 python_multiple_calculation = parser.parse_property_name("(Mgas,Mstar)")
+python_difference = lambda a, b: a-b
+python_nullary_lambda = lambda: rho
+python_unary_lambda = lambda x: rho
+
+
+def python_named_function(a, b=1.0):
+    return a*b
 
 
 def test_python_values_are_interpolated():
@@ -189,6 +196,57 @@ def test_calculations_are_inlined():
 def test_sub_lambdas_are_inlined():
     assert_matches_string(lambda: at(python_sub_lambda, dm_density_profile),
                           "at(Mgas+Mstar,dm_density_profile)")
+
+
+def test_sub_lambdas_can_be_called_or_used_as_values():
+    """A python lambda standing for a calculation works with or without the ()"""
+    assert_matches_string(lambda: python_nullary_lambda/mvir, "rho/mvir")
+    assert_matches_string(lambda: python_nullary_lambda()/mvir, "rho/mvir")
+    assert_matches_string(lambda: python_nullary_lambda()/mvir, "rho/mvir",
+                          name_resolution='python')
+
+
+def test_calling_a_sub_lambda_with_arguments_rejected():
+    assert_rejected(lambda: python_nullary_lambda(2), contains="takes no arguments")
+
+
+def test_python_functions_are_called_with_the_calculations_as_arguments():
+    """A python function of several arguments builds part of the calculation"""
+    assert_matches_string(lambda: python_difference(MDM, Mgas), "MDM-Mgas")
+    assert_matches_string(lambda: python_difference(MDM, Mgas), "MDM-Mgas",
+                          name_resolution='python')
+    assert_matches_string(lambda: python_difference(MDM, 2)/Mgas, "(MDM-2)/Mgas")
+    assert_matches_string(lambda: at(python_difference(Rvir, 1), dm_density_profile),
+                          "at(Rvir-1,dm_density_profile)")
+
+
+def test_python_functions_may_be_named_functions_with_defaults():
+    assert_matches_string(lambda: python_named_function(Mgas), "Mgas*1.0")
+    assert_matches_string(lambda: python_named_function(Mgas, 2), "Mgas*2")
+    # unlike a live calculation function, a python function may take keyword
+    # arguments, since it is genuinely called
+    assert_matches_string(lambda: python_named_function(Mgas, b=2), "Mgas*2")
+
+
+def test_calling_a_python_function_with_the_wrong_arguments_rejected():
+    """The python function is really called, so its arguments must match"""
+    message = assert_rejected(lambda: python_unary_lambda()/mvir,
+                              contains="python_unary_lambda")
+    assert "argument" in message
+    assert_rejected(lambda: python_difference(Mgas), contains="argument")
+    assert_rejected(lambda: python_difference(MDM, Mgas, Mvir), contains="argument")
+
+
+def test_python_functions_are_tangos_names_in_tangos_mode():
+    assert_matches_string(lambda: python_unary_lambda()/mvir,
+                          "python_unary_lambda()/mvir", name_resolution='tangos')
+    assert_matches_string(lambda: python_difference(MDM, Mgas),
+                          "python_difference(MDM,Mgas)", name_resolution='tangos')
+
+
+def test_python_function_used_as_a_value_rejected():
+    assert_rejected(lambda: at(python_difference, dm_density_profile),
+                    contains="python_difference")
 
 
 def test_default_mode_ignores_uninterpolatable_values():
@@ -289,6 +347,8 @@ def test_control_flow_in_a_called_function_rejected():
     def branching_function(value):
         return 1 if value else 2
 
+    with assert_raises(ControlFlowError):
+        to_calculation(lambda: branching_function(Mgas))
     with assert_raises(ControlFlowError):
         to_calculation(lambda: branching_function(Mgas), name_resolution='python')
 

--- a/tests/test_live_calculation_from_lambda.py
+++ b/tests/test_live_calculation_from_lambda.py
@@ -203,7 +203,7 @@ def test_sub_lambdas_can_be_called_or_used_as_values():
     assert_matches_string(lambda: python_nullary_lambda/mvir, "rho/mvir")
     assert_matches_string(lambda: python_nullary_lambda()/mvir, "rho/mvir")
     assert_matches_string(lambda: python_nullary_lambda()/mvir, "rho/mvir",
-                          name_resolution='python')
+                          python_names='always')
 
 
 def test_calling_a_sub_lambda_with_arguments_rejected():
@@ -214,7 +214,7 @@ def test_python_functions_are_called_with_the_calculations_as_arguments():
     """A python function of several arguments builds part of the calculation"""
     assert_matches_string(lambda: python_difference(MDM, Mgas), "MDM-Mgas")
     assert_matches_string(lambda: python_difference(MDM, Mgas), "MDM-Mgas",
-                          name_resolution='python')
+                          python_names='always')
     assert_matches_string(lambda: python_difference(MDM, 2)/Mgas, "(MDM-2)/Mgas")
     assert_matches_string(lambda: at(python_difference(Rvir, 1), dm_density_profile),
                           "at(Rvir-1,dm_density_profile)")
@@ -237,11 +237,11 @@ def test_calling_a_python_function_with_the_wrong_arguments_rejected():
     assert_rejected(lambda: python_difference(MDM, Mgas, Mvir), contains="argument")
 
 
-def test_python_functions_are_tangos_names_in_tangos_mode():
+def test_python_functions_are_tangos_names_in_never_mode():
     assert_matches_string(lambda: python_unary_lambda()/mvir,
-                          "python_unary_lambda()/mvir", name_resolution='tangos')
+                          "python_unary_lambda()/mvir", python_names='never')
     assert_matches_string(lambda: python_difference(MDM, Mgas),
-                          "python_difference(MDM,Mgas)", name_resolution='tangos')
+                          "python_difference(MDM,Mgas)", python_names='never')
 
 
 def test_python_function_used_as_a_value_rejected():
@@ -249,24 +249,24 @@ def test_python_function_used_as_a_value_rejected():
                     contains="python_difference")
 
 
-def test_default_mode_ignores_uninterpolatable_values():
-    """In 'auto' mode a name bound to something that isn't a calculation is a property"""
+def test_if_usable_mode_ignores_uninterpolatable_values():
+    """In 'if_usable' mode a name bound to something that isn't a calculation is a property"""
     assert_matches_string(lambda: python_module.pi, "python_module.pi")
 
 
-def test_python_mode_uses_the_python_value():
+def test_always_mode_uses_the_python_value():
     assert_matches_string(lambda: python_module.pi * Mvir,
-                          "%r*Mvir" % np.pi, name_resolution='python')
+                          "%r*Mvir" % np.pi, python_names='always')
     assert_matches_string(lambda: python_shadowing_property,
-                          "4.0", name_resolution='python')
+                          "4.0", python_names='always')
 
 
-def test_tangos_mode_ignores_the_python_scope():
+def test_never_mode_ignores_the_python_scope():
     assert_matches_string(lambda: python_radius, "python_radius",
-                          name_resolution='tangos')
+                          python_names='never')
     assert_matches_string(lambda: at(python_radius, dm_density_profile),
                           "at(python_radius,dm_density_profile)",
-                          name_resolution='tangos')
+                          python_names='never')
 
 
 def test_python_builtins_do_not_shadow_live_calculation_functions():
@@ -284,19 +284,19 @@ def test_closure_variables_are_interpolated():
         "at(5.0,dm_density_profile)"))
 
 
-def test_closure_variables_respect_tangos_mode():
+def test_closure_variables_respect_never_mode():
     def enclosing_scope():
         dm_density_profile = "not actually a profile"
         return to_calculation(lambda: at(5.0, dm_density_profile),
-                              name_resolution='tangos')
+                              python_names='never')
 
     assert str(enclosing_scope()) == str(parser.parse_property_name(
         "at(5.0,dm_density_profile)"))
 
 
-def test_unknown_name_resolution_mode():
+def test_unknown_python_names_mode():
     with assert_raises(ValueError):
-        to_calculation(lambda: Mvir, name_resolution='something_else')
+        to_calculation(lambda: Mvir, python_names='something_else')
 
 
 # ----------------------------------------------------------------------- rejections
@@ -350,7 +350,7 @@ def test_control_flow_in_a_called_function_rejected():
     with assert_raises(ControlFlowError):
         to_calculation(lambda: branching_function(Mgas))
     with assert_raises(ControlFlowError):
-        to_calculation(lambda: branching_function(Mgas), name_resolution='python')
+        to_calculation(lambda: branching_function(Mgas), python_names='always')
 
 
 def test_lambda_with_arguments_rejected():


### PR DESCRIPTION
Adds `tangos.live_calculation.from_lambda`, an alternative front-end to the live-calculation mini-language in which a calculation is written as a python lambda instead of a string. It produces exactly the same `Calculation` objects as the parser, and can be passed anywhere a string can:

```python
h.calculate(lambda: Vvir())
h.calculate(lambda: at(Rvir/2, dm_density_profile))
ts.calculate_all(lambda: later(5).Mvir, "Mvir")
h.calculate_for_progenitors(lambda: SFR_histogram[0])
```

Everything expressible as a string is expressible as a lambda: stored properties, live properties, links, array elements, multiple calculations and every operator. Only two spellings differ, both because the lambda is genuine python: `!` becomes `~`, and python's precedence applies rather than the mini-language's, so `a<10 & b>5` needs brackets as `(a<10) & (b>5)`.

## How it works

A lambda stores names plus a rule for looking them up, not values. It is therefore cloned with its globals and closure cells replaced by symbolic stand-ins and then simply called; the operators on those stand-ins build `Calculation` objects rather than computing anything. This is the same idea as sympy's `Symbol` or jax tracing.

## Name resolution

A name that does not resolve to a python variable is a live-calculation name — always, in every mode. The `python_names` argument to `to_calculation` controls what happens when a name *does* resolve:

| `python_names` | behaviour |
| --- | --- |
| `'if_usable'` (default) | use the python value if it is something a calculation can contain — a number, a string, a tuple of those, a `Calculation`, or a python function; otherwise treat the name as a live-calculation name |
| `'always'` | always use the python value where the name resolves, so `numpy.pi` can be interpolated, at the cost of a stray variable silently shadowing a property of the same name |
| `'never'` | never consult the python scope |

In every mode python's builtins are excluded, so the live-calculation `abs()` and `sum()` are not shadowed by the python functions of the same name.

A name resolving to a python function is used as that function, which makes calculations composable:

```python
half_radius = lambda: Rvir/2
h.calculate(lambda: at(half_radius, profile))      # at(Rvir/2,profile)
h.calculate(lambda: at(half_radius(), profile))    # the same, with or without the ()

difference = lambda a, b: a-b
ts.calculate_all(lambda: difference(MDM, Mgas))    # MDM-Mgas
```

A function taking arguments is genuinely called, with the calculations as its arguments, so it assembles part of the calculation; its arguments are checked against its signature, and a mismatch is an error rather than a silent call to a live-calculation function that does not exist. Under `python_names='never'` none of this applies and such a name is simply a live-calculation function.

## Rejected lambdas

Control flow cannot be captured by tracing, so it is rejected rather than silently mistraced: first by a static scan of the bytecode, which reports the offending source line with a caret, and then dynamically as a backstop for branching that happens inside an ordinary function the lambda calls. Other misuses — lambdas taking arguments, keyword arguments, lists, slicing, unsupported operators, self-reference — raise `LambdaCalculationError` with an explanation of what to write instead.

## Wiring

`parser.parse_property_name_if_required` now dispatches on what it is given: a `Calculation` is returned unchanged, a string is parsed exactly as before, and a function taking no arguments is traced. Every route into the live calculation system already funnels through that function or through `parse_property_names`, so lambdas work transparently in `calculate`, `calculate_all`, `calculate_for_descendants`, `calculate_for_progenitors` and the merger tree's calculations, and can be mixed freely with strings in the same call. `MultiCalculation` and `Link` use the same dispatch, so calculations can also be assembled from lambdas by hand. Anything that is neither a string, a lambda nor a `Calculation` now raises a `TypeError` naming what is accepted.

## Changes to the existing language

Two changes make the string and lambda forms line up:

* The parser now also accepts `~` as a synonym for `!`, since python's `not` cannot be captured. `!` continues to work exactly as before.
* `str()` of a calculation now uses operator and array-index notation rather than exposing the underlying function names, so `Mvir/Vvir()` no longer comes back as `divide(Mvir,Vvir())` and `dm_density_profile[3]` no longer as `element(dm_density_profile,3)`.

Brackets are added only where the mini-language would otherwise regroup the expression, taking account of its operators all being right-associative and its prefix operators binding less tightly than any infix one. Where the grammar allows neither brackets nor the short form — to the left of a `.` or a `[` — the function form is used for that sub-expression instead, e.g. `add(a,b).c` and `element(a,0)[1]`. Brackets around a single calculation are now treated as grouping rather than producing a one-element `MultiCalculation`, so that the printed form parses back to an identical calculation.

The operator tables move from the parser into `live_calculation` itself, so that the parser and the printer share one definition of the operators and their precedence.

## Documentation

`docs/live_calculation.md` is rewritten as a single introduction to the system rather than a description of the string language with a lambda section appended. It presents the two forms side by side from the start, builds up from stored properties through arithmetic, live properties, arrays, links and histogram reassembly, and gives the string form's unusual operator precedence a section of its own, since that is the part of the system most likely to surprise. Along the way it corrects `Ngas()` to `NGas()`, adds the dozen built-in functions and four comparison operators that were undocumented, and fixes the description of `at()`, which required a stored array immediately before an example that passed it an expression.

## Testing

`tests/test_live_calculation_from_lambda.py` is new: parity against the parser for every construct in the language, the `python_names` modes, python functions and sub-lambdas, closure handling, each category of rejection, end-to-end evaluation against a test database, and lambdas passed directly to `calculate`, `calculate_all`, `calculate_for_descendants` and `calculate_for_progenitors` — including mixed with strings, to confirm the string form is unaffected. One test asserts that every operator known to the parser has a lambda spelling, so the two front-ends cannot silently diverge. `tests/test_live_calculation.py` gains round-trip tests over 40 expressions, checking that printing a calculation and re-parsing it gives back an identical calculation. Every code example in the documentation was checked by comparing the lambda against the equivalent string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfjpwetZvixsMQVjmpq97R